### PR TITLE
🕰  always take latest reference

### DIFF
--- a/src/export/utils/walkArticle.ts
+++ b/src/export/utils/walkArticle.ts
@@ -161,11 +161,26 @@ export async function walkArticle(
       const { content } = version.data;
       // Extract the label: '@article{SimPEG2015,\n...' ➡️ 'SimPEG2015'
       const label = content.slice(content.indexOf('{') + 1, content.indexOf(','));
-      references[basekey(key)] = {
-        label,
-        bibtex: content,
-        version,
-      };
+
+      const existing = references[basekey(key)];
+      if (existing) {
+        const ve = existing.version.id.version;
+        const v = version.id.version;
+        // if existing, only update if incoming version is defined and greater than the existing
+        if (ve == null || ve < (v ?? 0)) {
+          references[basekey(key)] = {
+            label,
+            bibtex: content,
+            version,
+          };
+        }
+      } else {
+        references[basekey(key)] = {
+          label,
+          bibtex: content,
+          version,
+        };
+      }
     }),
   );
 


### PR DESCRIPTION
This covers the case where there may be multiple versions of a reference cited in a document, and means the latest is always taken independent of the order they are cited in.