### PR TITLE
Changes to Cloud Run usage

### DIFF
--- a/src/export/markdown/index.ts
+++ b/src/export/markdown/index.ts
@@ -33,7 +33,7 @@ export async function articleToMarkdown(session: ISession, versionId: VersionId,
   const article = await walkArticle(session, data);
 
   const imageFilenames = await writeImagesToFiles(
-    session.$logger,
+    session.log,
     article.images,
     opts?.images ?? 'images',
   );

--- a/src/export/markdown/index.ts
+++ b/src/export/markdown/index.ts
@@ -32,7 +32,11 @@ export async function articleToMarkdown(session: ISession, versionId: VersionId,
   if (data.kind !== KINDS.Article) throw new Error('Not an article');
   const article = await walkArticle(session, data);
 
-  const imageFilenames = await writeImagesToFiles(article.images, opts?.images ?? 'images');
+  const imageFilenames = await writeImagesToFiles(
+    session.$logger,
+    article.images,
+    opts?.images ?? 'images',
+  );
   const localization = localizationOptions(session, imageFilenames, article.references);
   const content = article.children.map((child) => {
     if (!child.version || !child.state) return '';

--- a/src/export/pdf/index.ts
+++ b/src/export/pdf/index.ts
@@ -14,8 +14,10 @@ export async function articleToPdf(session: Session, versionId: VersionId, opts:
   const basename = path.basename(opts.filename, path.extname(opts.filename));
   const tex_filename = `${basename}.tex`;
   const pdf_filename = `${basename}.pdf`;
+  const log_filename = `${basename}.log`;
   const targetTexFilePath = path.join(outputPath, tex_filename);
   const outputPdfFile = path.join(outputPath, pdf_filename);
+  const outputLogFile = path.join(outputPath, log_filename);
 
   const article = await articleToTex(session, versionId, {
     ...opts,
@@ -34,13 +36,18 @@ export async function articleToPdf(session: Session, versionId: VersionId, opts:
   }
 
   const built_pdf = path.join(buildPath, pdf_filename);
-  if (!fs.existsSync(built_pdf)) {
-    session.log.error(`Could not find ${built_pdf} as expected, pdf export failed`);
+  if (fs.existsSync(built_pdf)) {
+    await copyFile(built_pdf, outputPdfFile);
+    session.$logger.debug(`Copied PDF file to ${outputPdfFile}`);
+  } else {
+    session.$logger.error(`Could not find ${built_pdf} as expected, pdf export failed`);
     throw Error(`Could not find ${built_pdf} as expected, pdf export failed`);
   }
 
-  await copyFile(built_pdf, outputPdfFile);
-  session.log.debug(`Copied PDF file to ${outputPdfFile}`);
+  const built_log = path.join(buildPath, log_filename);
+  if (fs.existsSync(built_log)) {
+    await copyFile(built_log, outputLogFile);
+  }
 
   return article;
 }

--- a/src/export/pdf/index.ts
+++ b/src/export/pdf/index.ts
@@ -9,7 +9,11 @@ import { ISession } from '../../session/types';
 
 const copyFile = util.promisify(fs.copyFile);
 
-export async function articleToPdf(session: Session, versionId: VersionId, opts: TexExportOptions) {
+export async function articleToPdf(
+  session: ISession,
+  versionId: VersionId,
+  opts: TexExportOptions,
+) {
   const outputPath = path.dirname(opts.filename);
   const basename = path.basename(opts.filename, path.extname(opts.filename));
   const tex_filename = `${basename}.tex`;
@@ -38,9 +42,9 @@ export async function articleToPdf(session: Session, versionId: VersionId, opts:
   const built_pdf = path.join(buildPath, pdf_filename);
   if (fs.existsSync(built_pdf)) {
     await copyFile(built_pdf, outputPdfFile);
-    session.$logger.debug(`Copied PDF file to ${outputPdfFile}`);
+    session.log.debug(`Copied PDF file to ${outputPdfFile}`);
   } else {
-    session.$logger.error(`Could not find ${built_pdf} as expected, pdf export failed`);
+    session.log.error(`Could not find ${built_pdf} as expected, pdf export failed`);
     throw Error(`Could not find ${built_pdf} as expected, pdf export failed`);
   }
 

--- a/src/export/pdf/index.ts
+++ b/src/export/pdf/index.ts
@@ -9,38 +9,38 @@ import { ISession } from '../../session/types';
 
 const copyFile = util.promisify(fs.copyFile);
 
-export async function articleToPdf(
-  session: ISession,
-  versionId: VersionId,
-  opts: TexExportOptions,
-) {
+export async function articleToPdf(session: Session, versionId: VersionId, opts: TexExportOptions) {
+  const outputPath = path.dirname(opts.filename);
   const basename = path.basename(opts.filename, path.extname(opts.filename));
   const tex_filename = `${basename}.tex`;
   const pdf_filename = `${basename}.pdf`;
+  const targetTexFilePath = path.join(outputPath, tex_filename);
+  const outputPdfFile = path.join(outputPath, pdf_filename);
 
   const article = await articleToTex(session, versionId, {
     ...opts,
-    filename: tex_filename,
+    filename: targetTexFilePath,
     template: opts.template ?? 'default',
     useBuildFolder: true,
     texIsIntermediate: true,
   });
 
-  const CMD = `cd _build;latexmk -f -xelatex -synctex=1 -interaction=nonstopmode -file-line-error -latexoption="-shell-escape" ${tex_filename}`;
+  const buildPath = path.join(outputPath, '_build');
+  const CMD = `cd ${buildPath};latexmk -f -xelatex -synctex=1 -interaction=nonstopmode -file-line-error -latexoption="-shell-escape" ${tex_filename}`;
   try {
     await exec(CMD);
   } catch (err) {
     session.log.error(`Error while invoking mklatex: ${err}`);
   }
 
-  const built_pdf = path.join('_build', pdf_filename);
+  const built_pdf = path.join(buildPath, pdf_filename);
   if (!fs.existsSync(built_pdf)) {
     session.log.error(`Could not find ${built_pdf} as expected, pdf export failed`);
     throw Error(`Could not find ${built_pdf} as expected, pdf export failed`);
   }
 
-  await copyFile(built_pdf, pdf_filename);
-  session.log.debug(`Copied PDF file to ${pdf_filename}`);
+  await copyFile(built_pdf, outputPdfFile);
+  session.log.debug(`Copied PDF file to ${outputPdfFile}`);
 
   return article;
 }

--- a/src/export/tex/index.ts
+++ b/src/export/tex/index.ts
@@ -65,12 +65,12 @@ export async function articleToTex(
   const templateOptions = loadTemplateOptions(opts);
 
   // Only use a build path if no template && no pdf target requested
-  session.log.info('Starting articleToTex...');
-  session.log.info(`With Options: ${JSON.stringify(opts)}`);
+  session.log.debug('Starting articleToTex...');
+  session.log.debug(`With Options: ${JSON.stringify(opts)}`);
 
   const { buildPath, outputFilename } = makeBuildPaths(session.log, opts);
 
-  session.log.info('Fetching data from API...');
+  session.log.debug('Fetching data from API...');
   const [block, version] = await Promise.all([
     new Block(session, convertToBlockId(versionId)).get(),
     new Version(session, versionId).get(),
@@ -79,18 +79,18 @@ export async function articleToTex(
   const { data } = version;
   if (data.kind !== KINDS.Article) throw new Error('Not an article');
 
-  session.log.info('Start walkArticle...');
+  session.log.debug('Start walkArticle...');
   const article = await walkArticle(session, data, tagged);
 
-  session.log.info('Start localizing images..');
+  session.log.debug('Start localizing images..');
   const imageFilenames = await writeImagesToFiles(
-    session.$logger,
+    session.log,
     article.images,
     opts?.images ?? 'images',
     buildPath,
   );
 
-  session.log.info('Finding tagged content and write to files...');
+  session.log.debug('Finding tagged content and write to files...');
   const taggedFilenames: Record<string, string> = Object.entries(article.tagged)
     .filter(([tag, children]) => {
       if (children.length === 0) {
@@ -111,7 +111,7 @@ export async function articleToTex(
     })
     .reduce((obj, { tag, filename }) => ({ ...obj, [tag]: filename }), {});
 
-  session.log.info('Building front matter...');
+  session.log.debug('Building front matter...');
   const frontMatter = stringifyFrontMatter(
     await buildFrontMatter(
       session,

--- a/src/export/tex/index.ts
+++ b/src/export/tex/index.ts
@@ -16,8 +16,8 @@ import {
   exportFromOxaLink,
   walkArticle,
   writeImagesToFiles,
-  exec,
   makeBuildPaths,
+  makeExecutable,
 } from '../utils';
 import { TexExportOptions } from './types';
 import {
@@ -147,7 +147,8 @@ export async function articleToTex(
     session.log.debug('Running JTEX...');
     const CMD = `jtex render ${content_tex}`;
     try {
-      await exec(CMD);
+      const jtex = makeExecutable(CMD, session.$logger);
+      await jtex();
     } catch (err) {
       session.log.error(`Error while invoking jtex: ${err}`);
     }

--- a/src/export/tex/index.ts
+++ b/src/export/tex/index.ts
@@ -84,6 +84,7 @@ export async function articleToTex(
 
   session.log.info('Start localizing images..');
   const imageFilenames = await writeImagesToFiles(
+    session.$logger,
     article.images,
     opts?.images ?? 'images',
     buildPath,
@@ -147,7 +148,7 @@ export async function articleToTex(
     session.log.debug('Running JTEX...');
     const CMD = `jtex render ${content_tex}`;
     try {
-      const jtex = makeExecutable(CMD, session.$logger);
+      const jtex = makeExecutable(CMD, session.log);
       await jtex();
     } catch (err) {
       session.log.error(`Error while invoking jtex: ${err}`);

--- a/src/export/utils/exec.ts
+++ b/src/export/utils/exec.ts
@@ -1,5 +1,6 @@
 import util from 'util';
 import child_process from 'child_process';
+import { Logger } from '../../logging';
 
 function execWrapper(
   command: string,
@@ -12,5 +13,20 @@ function execWrapper(
 }
 
 const exec = util.promisify(execWrapper);
+
+function makeExecWrapper(command: string, log: Logger) {
+  return function inner(
+    callback?: (error: child_process.ExecException | null, stdout: string, stderr: string) => void,
+  ) {
+    const childProcess = child_process.exec(command, callback);
+    childProcess.stdout?.on('data', (data: any) => log.info(data));
+    childProcess.stderr?.on('data', (data: any) => log.error(data));
+    return childProcess;
+  };
+}
+
+export function makeExecutable(command: string, log: Logger) {
+  return util.promisify(makeExecWrapper(command, log));
+}
 
 export default exec;

--- a/src/export/utils/exec.ts
+++ b/src/export/utils/exec.ts
@@ -19,7 +19,7 @@ function makeExecWrapper(command: string, log: Logger) {
     callback?: (error: child_process.ExecException | null, stdout: string, stderr: string) => void,
   ) {
     const childProcess = child_process.exec(command, callback);
-    childProcess.stdout?.on('data', (data: any) => log.info(data));
+    childProcess.stdout?.on('data', (data: any) => log.debug(data));
     childProcess.stderr?.on('data', (data: any) => log.error(data));
     return childProcess;
   };

--- a/src/export/utils/index.ts
+++ b/src/export/utils/index.ts
@@ -3,4 +3,5 @@ export * from './walkArticle';
 export * from '../tex/frontMatter';
 export * from './getImageSrc';
 export * from './writeImagesToFiles';
+export * from './makeBuildPaths';
 export { default as exec } from './exec';

--- a/src/export/utils/index.ts
+++ b/src/export/utils/index.ts
@@ -4,4 +4,4 @@ export * from '../tex/frontMatter';
 export * from './getImageSrc';
 export * from './writeImagesToFiles';
 export * from './makeBuildPaths';
-export { default as exec } from './exec';
+export { default as exec, makeExecutable } from './exec';

--- a/src/export/utils/makeBuildPaths.ts
+++ b/src/export/utils/makeBuildPaths.ts
@@ -1,0 +1,20 @@
+import { TexExportOptions } from 'export/tex/types';
+import { Logger } from 'logging';
+import path from 'path';
+import fs from 'fs';
+
+export function makeBuildPaths(log: Logger, opts: TexExportOptions) {
+  const outputPath = path.dirname(opts.filename);
+  const outputFilename = path.basename(opts.filename);
+  const buildPath =
+    opts.useBuildFolder ?? !!opts.template ? path.join(outputPath, '_build') : outputPath;
+  log.info(`Output Path ${outputPath}`);
+  log.info(`Filename ${outputFilename}`);
+  log.info(`Build path set to ${buildPath}`);
+  if (!fs.existsSync(buildPath)) fs.mkdirSync(path.dirname(buildPath), { recursive: true });
+  return {
+    buildPath,
+    outputPath,
+    outputFilename,
+  };
+}

--- a/src/export/utils/makeBuildPaths.ts
+++ b/src/export/utils/makeBuildPaths.ts
@@ -8,9 +8,9 @@ export function makeBuildPaths(log: Logger, opts: TexExportOptions) {
   const outputFilename = path.basename(opts.filename);
   const buildPath =
     opts.useBuildFolder ?? !!opts.template ? path.join(outputPath, '_build') : outputPath;
-  log.info(`Output Path ${outputPath}`);
-  log.info(`Filename ${outputFilename}`);
-  log.info(`Build path set to ${buildPath}`);
+  log.debug(`Output Path ${outputPath}`);
+  log.debug(`Filename ${outputFilename}`);
+  log.debug(`Build path set to ${buildPath}`);
   if (!fs.existsSync(buildPath)) fs.mkdirSync(path.dirname(buildPath), { recursive: true });
   return {
     buildPath,

--- a/src/export/utils/writeImagesToFiles.ts
+++ b/src/export/utils/writeImagesToFiles.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import fetch from 'node-fetch';
 import { Blocks } from '@curvenote/blocks';
+import { Logger } from 'logging';
 import { Block, Version } from '../../models';
 import { ArticleState } from './walkArticle';
 import { getImageSrc } from './getImageSrc';
@@ -48,6 +49,7 @@ function makeUniqueFilename(
 }
 
 export async function writeImagesToFiles(
+  log: Logger,
   images: ArticleState['images'],
   basePath: string,
   buildPath?: string,
@@ -70,7 +72,7 @@ export async function writeImagesToFiles(
       );
       const filename = path.join(buildPath ?? '', referencableFilename);
       if (!fs.existsSync(filename)) fs.mkdirSync(path.dirname(filename), { recursive: true });
-      console.log(`Writing ${filename}`);
+      log.debug(`Writing ${filename}`);
       fs.writeFileSync(filename, buffer);
       filenames[key] = referencableFilename;
       takenFilenames.add(referencableFilename);

--- a/src/export/utils/writeImagesToFiles.ts
+++ b/src/export/utils/writeImagesToFiles.ts
@@ -54,7 +54,7 @@ export async function writeImagesToFiles(
 ) {
   const takenFilenames: Set<string> = new Set();
   const filenames: Record<string, string> = {};
-  await Promise.all(
+  const p = await Promise.all(
     Object.entries(images).map(async ([key, image]) => {
       const [block] = await Promise.all([new Block(image.session, image.id).get(), image.get()]);
       const { src, content_type } = getImageSrc(image);
@@ -70,10 +70,12 @@ export async function writeImagesToFiles(
       );
       const filename = path.join(buildPath ?? '', referencableFilename);
       if (!fs.existsSync(filename)) fs.mkdirSync(path.dirname(filename), { recursive: true });
+      console.log(`Writing ${filename}`);
       fs.writeFileSync(filename, buffer);
       filenames[key] = referencableFilename;
       takenFilenames.add(referencableFilename);
     }),
   );
+
   return filenames;
 }


### PR DESCRIPTION
Various changes to the Tex & PDF export to enable usage in Curvenote's cloud run containers. Also significant for the API is that the `--output, -o` outputs can now be a path to a target file in a different folder. `_build` will be setup relative to that location at the moment.