### PR TITLE
dont track package-lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ temp/
 node_modules/
 yalc.lock
 .yalc/
+package-lock.json
 *.docx
 src/version.ts


### PR DESCRIPTION
Every time I run `yarn dev:cli` I get a package lock file generated which is easy to accidentally commit. I believe we want to ignore this always