### PR TITLE
allow suffix for caption label to be configured

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "jsdom": "^18.0.0",
     "jsonwebtoken": "^8.5.1",
     "node-fetch": "^2.6.5",
-    "prosemirror-docx": "^0.0.10",
+    "prosemirror-docx": "^0.0.11",
     "prosemirror-model": "^1.15.0",
     "prosemirror-state": "^1.3.4",
     "redux": "^4.1.1",

--- a/src/export/word/schema.ts
+++ b/src/export/word/schema.ts
@@ -21,7 +21,7 @@ interface Styles {
   callout?: IParagraphOptions;
   equation?: IParagraphOptions;
   iframe?: IParagraphOptions;
-  figcaption?: IParagraphOptions;
+  figcaption?: IParagraphOptions & { suffix?: string };
   time?: IRunOptions;
 }
 
@@ -141,9 +141,10 @@ export function getNodesAndMarks(styles?: Styles) {
       const { kind } = node.attrs as Nodes.Figcaption.Attrs;
       const id = (state as any).nextCaptionId;
       const numbered = (state as any).nextCaptionNumbered;
+      const options = styles?.figcaption?.suffix ? { suffix: styles.figcaption.suffix } : undefined;
       if (numbered && kind) {
         const captionKind = figCaptionToWordCaption(kind);
-        state.captionLabel(id, captionKind);
+        state.captionLabel(id, captionKind, options);
       }
       state.renderInline(node);
       state.closeBlock(node, { ...defaultStyles.figcaption, ...styles?.figcaption });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4342,10 +4342,10 @@ prosemirror-collab@^1.2.2:
   dependencies:
     prosemirror-state "^1.0.0"
 
-prosemirror-docx@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/prosemirror-docx/-/prosemirror-docx-0.0.10.tgz#099fd67054438c72674154d3bbe5ef58bcb14814"
-  integrity sha512-mzO0HeYyHyYzrULHuyi+JCs39B7yww/cnY46Rr7Vi30q+IDJgWRSOC0gKwYW3+w2X8IIblfhxCz/217VPUDfWA==
+prosemirror-docx@^0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/prosemirror-docx/-/prosemirror-docx-0.0.11.tgz#2d43dd62b00f82f400b2530e2413d484bb5ea015"
+  integrity sha512-GqPl0F9DZufjJorAqEAD7XMeQjq4nCUgDsPtCtyHEKf3SZ67niqxmaokjgJPPvl3n778HZD3ASZ1/op7jZujdw==
   dependencies:
     buffer-image-size "^0.6.4"
     docx "^7.3.0"


### PR DESCRIPTION
Allow `figcaption` to be configured with custom suffix (for instance, indentation).
Requires https://github.com/curvenote/prosemirror-docx/pull/10