### PR TITLE
fix/failed fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@curvenote/blocks": "1.1.6",
     "@curvenote/schema": "0.11.8",
     "@reduxjs/toolkit": "^1.6.2",
+    "bottleneck": "^2.19.5",
     "chalk": "^4.1.2",
     "commander": "^8.3.0",
     "date-fns": "^2.25.0",

--- a/src/actions/getLatest.ts
+++ b/src/actions/getLatest.ts
@@ -7,12 +7,14 @@ export async function getLatestVersion<T extends ALL_BLOCKS>(
   blockId: BlockId,
   query?: VersionQueryOpts,
 ) {
+  session.log.debug(`getLatestVersion(${JSON.stringify(blockId)})`);
   const block = await new Block(session, blockId).get();
   const { latest_version } = block.data;
   if (!latest_version)
     throw new Error(
       `Block with name "${block.data.name}" has no versions, do you need to save the draft?`,
     );
+  session.log.debug(`Requesting latest version ${latest_version}`);
   const versionId = { ...block.id, version: latest_version };
   session.log.debug(`Fetching latest version of block: ${versionIdToString(versionId)}`);
   const version = await new Version<T>(session, versionId).get(query);

--- a/src/export/pdf/index.ts
+++ b/src/export/pdf/index.ts
@@ -26,7 +26,7 @@ export async function articleToPdf(
   const article = await articleToTex(session, versionId, {
     ...opts,
     filename: targetTexFilePath,
-    template: opts.template ?? 'default',
+    template: opts.template ?? 'public/default',
     useBuildFolder: true,
     texIsIntermediate: true,
   });

--- a/src/export/word/index.ts
+++ b/src/export/word/index.ts
@@ -28,7 +28,7 @@ export async function articleToWord(
   const [block, version] = await Promise.all([
     new Block(session, versionId).get(),
     new Version(session, versionId).get(),
-    getChildren(session, versionId), // This loads all the children quickly
+    getChildren(session, versionId), // This loads all the children quickly, but does not fetch
   ]);
   if (version.data.kind !== KINDS.Article)
     throw new Error(`The export source must be of kind "Article" not ${version.data.kind}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1266,6 +1266,11 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+bottleneck@^2.19.5:
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
- fixed default template name
- added a rate limiter for fetching child blocks/versions and for fetching references in walkArticle, without any rate limiting the async map call could potentially launch 100s of concurrent requests if there are that many items in the export target.