### PR TITLE
🚣🏿‍♂️  pull a single content path

### DIFF
--- a/src/cli/services/sync.ts
+++ b/src/cli/services/sync.ts
@@ -12,6 +12,7 @@ function makeSyncInitCLI(program: Command) {
 function makeSyncPullCLI(program: Command) {
   const command = new Command('pull')
     .description('Pull all information for a Curvenote project')
+    .argument('[folder]', 'The location of the content to pull')
     .action(clirun(sync.pull, { program, requireConfig: true }));
   return command;
 }

--- a/src/sync/pull.ts
+++ b/src/sync/pull.ts
@@ -2,44 +2,103 @@ import inquirer from 'inquirer';
 import pLimit from 'p-limit';
 import { projectToJupyterBook } from '../export';
 import { Project } from '../models';
-import { CurvenoteConfig } from '../config';
+import { CurvenoteConfig, CURVENOTE_YML, SyncConfig } from '../config';
 import { ISession } from '../session/types';
 import { tic } from '../export/utils/exec';
 import { projectLogString } from './utls';
 import { LogLevel, getLevel } from '../logging';
 
+/**
+ * Check the item has a remote
+ *
+ * @param item the item to pull
+ * @returns boolean
+ */
+function hasRemote(item: SyncConfig): boolean {
+  return Boolean(item.link) && Boolean(item.id);
+}
+
+/**
+ * Check the item exists and has a remote
+ *
+ * @param folder the local path of the folder to pull, used in message only
+ * @param item the item to validate, whcih may be undefined
+ * @returns a validated SyncConfig
+ */
+function throwIfMissingOrNoRemote(folder: string, item?: SyncConfig): SyncConfig {
+  if (!item) throw new Error(`Could not find ${folder} in ${CURVENOTE_YML}`);
+  if (!hasRemote(item)) throw new Error(`Item ${folder} has no remote, cannot pull`);
+  return item as SyncConfig;
+}
+
+/**
+ * Pull content for a project
+ *
+ * @param session the session
+ * @param id the item id which is also the project id for remote content
+ * @param folder the local folder to pull
+ * @param level logging level from the cli
+ */
+async function pullProject(session: ISession, id: string, folder: string, level?: LogLevel) {
+  const log = getLevel(session.log, level ?? LogLevel.debug);
+  const project = await new Project(session, id).get();
+  const toc = tic();
+  log(`Pulling ${folder} from ${projectLogString(project)}`);
+  await projectToJupyterBook(session, project.id, { path: folder, writeConfig: false });
+  log(toc(`🚀 Pulled ${folder} in %s`));
+}
+
+/**
+ * Pull content for all projects in the config.sync that have remotes
+ *
+ * @param session
+ * @param opts
+ */
 export async function pullProjects(
   session: ISession,
-  opts: { config: CurvenoteConfig; level?: LogLevel },
+  opts: { config: CurvenoteConfig; level?: LogLevel; folder?: string },
 ) {
   const { config } = opts;
   const limit = pLimit(1);
-  const log = getLevel(session.log, opts.level ?? LogLevel.debug);
-  await Promise.all(
-    config.sync.map(({ folder, id }) =>
-      limit(async () => {
-        const project = await new Project(session, id).get();
-        const toc = tic();
-        log(`Pulling ${folder} from ${projectLogString(project)}`);
-        await projectToJupyterBook(session, project.id, { path: folder, writeConfig: false });
-        log(toc(`🚀 Pulled ${folder} in %s`));
-      }),
-    ),
-  );
+  if (opts.folder) {
+    const item = throwIfMissingOrNoRemote(
+      opts.folder,
+      config.sync.find((i) => i.folder === opts.folder),
+    );
+    await pullProject(session, item.id, opts.folder, opts.level);
+  } else {
+    const remoteContentOnly = config.sync.filter(hasRemote);
+    await Promise.all(
+      remoteContentOnly.map(({ folder, id }) =>
+        limit(async () => pullProject(session, id, folder, opts.level)),
+      ),
+    );
+  }
 }
 
-export async function pull(session: ISession) {
+export async function pull(session: ISession, folder?: string) {
   const { config } = session;
   if (!config) throw new Error('Must have config to pull content.');
+
+  if (folder)
+    throwIfMissingOrNoRemote(
+      folder,
+      config.sync.find((item) => item.folder === folder),
+    );
+
+  const message = folder
+    ? `Pulling will overwrite all content in ${folder}. Are you sure?`
+    : 'Pulling content will overwrite all content in folders. Are you sure?';
+
   const { confirm } = await inquirer.prompt([
     {
       name: 'confirm',
-      message: 'Pulling content will overwrite all content in folders. Are you sure?',
+      message,
       type: 'confirm',
       default: false,
     },
   ]);
   if (confirm) {
-    await pullProjects(session, { config, level: LogLevel.info });
+    await pullProjects(session, { config, level: LogLevel.info, folder });
   }
 }


### PR DESCRIPTION
you can now specify a folder on the `curvenote pull [folder]` cli which must match one of your local content folders. If that folder has a remote, then pull that content only.