### PR TITLE
🌄 Improve image handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "katex": "^0.15.2",
         "lodash.throttle": "^4.1.1",
         "mime-types": "^2.1.35",
-        "mystjs": "^0.0.6",
+        "myst-spec": "^0.0.4",
+        "mystjs": "^0.0.7",
         "nanoid": "^3.3.2",
         "node-fetch": "^2.6.7",
         "p-limit": "^3.1.0",
@@ -1147,6 +1148,41 @@
         "date-fns": "^2.22.1"
       }
     },
+    "node_modules/@curvenote/schema/node_modules/myst-spec": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/myst-spec/-/myst-spec-0.0.2.tgz",
+      "integrity": "sha512-jGOFSDDdYip9JsW3KPHfq7v2AC9c4Pg7gM4HEtNX2bhsHQNqldU6nZv+QmXtxIwDlfYAGVIHgQL3XNfM+7QeEg=="
+    },
+    "node_modules/@curvenote/schema/node_modules/mystjs": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/mystjs/-/mystjs-0.0.5.tgz",
+      "integrity": "sha512-J+hYVwIyXN0H6/wwmANUc5rs9MdLJRcQ2ABm7sZPGidwwNSPSg105xlN4eFTxBksKh7PxIHkEWBJCxYPb42QuA==",
+      "dependencies": {
+        "classnames": "^2.3.1",
+        "he": "^1.2.0",
+        "markdown-it": "^12.3.2",
+        "markdown-it-amsmath": "^0.3.1",
+        "markdown-it-deflist": "^2.1.0",
+        "markdown-it-docutils": "0.1.4",
+        "markdown-it-dollarmath": "^0.4.2",
+        "markdown-it-footnote": "^3.0.3",
+        "markdown-it-front-matter": "^0.2.3",
+        "markdown-it-myst-extras": "0.2.0",
+        "markdown-it-task-lists": "^2.1.1",
+        "mdast-util-find-and-replace": "^2.1.0",
+        "mdast-util-to-hast": "^12.1.1",
+        "myst-spec": "0.0.2",
+        "rehype-format": "^4.0.1",
+        "rehype-stringify": "^9.0.3",
+        "unified": "^10.1.1",
+        "unist-builder": "^3.0.0",
+        "unist-util-find-after": "^4.0.0",
+        "unist-util-map": "^3.0.0",
+        "unist-util-remove": "^3.1.0",
+        "unist-util-select": "^4.0.1",
+        "unist-util-visit": "^4.1.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -1842,6 +1878,11 @@
       "resolved": "https://registry.npmjs.org/@types/copyfiles/-/copyfiles-2.4.1.tgz",
       "integrity": "sha512-v2JLxXeWUeWYWVo3/tlpxqiDCvgewSvf58HHjHYNaCi0lAthhRQ7jz8InxGzJsrMbWmWkYaxBO+BEtKjBU4ebw==",
       "dev": true
+    },
+    "node_modules/@types/extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -5310,6 +5351,45 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-mdast": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-8.3.1.tgz",
+      "integrity": "sha512-nxLcom1oW5y/1CyaV24K16LOfYbAIS74BDbCPW6WduzAYTAVDp3g/DM1CY6Ngo+Dx5itLzvmCm7SnUHBZd3NVQ==",
+      "dependencies": {
+        "@types/extend": "^3.0.0",
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "extend": "^3.0.0",
+        "hast-util-has-property": "^2.0.0",
+        "hast-util-is-element": "^2.0.0",
+        "hast-util-to-text": "^3.0.0",
+        "mdast-util-phrasing": "^3.0.0",
+        "mdast-util-to-string": "^3.0.0",
+        "rehype-minify-whitespace": "^5.0.0",
+        "trim-trailing-lines": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-3.1.1.tgz",
+      "integrity": "sha512-7S3mOBxACy8syL45hCn3J7rHqYaXkxRfsX6LXEU5Shz4nt4GxdjtMUtG+T6G/ZLUHd7kslFAf14kAN71bz30xA==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "hast-util-is-element": "^2.0.0",
+        "unist-util-find-after": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.0.tgz",
@@ -7471,6 +7551,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mdast-util-phrasing": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.0.tgz",
+      "integrity": "sha512-S+QYsDRLkGi8U7o5JF1agKa/sdP+CNGXXLqC17pdTVL8FHHgQEiwFGa9yE5aYtUxNiFGYoaDy9V1kC85Sz86Gg==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-to-hast": {
       "version": "12.1.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.1.1.tgz",
@@ -7487,6 +7580,15 @@
         "unist-util-position": "^4.0.0",
         "unist-util-visit": "^4.0.0"
       },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
+      "integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -7702,11 +7804,12 @@
       "integrity": "sha512-1j7184Wmg5lhgSXt6AXtG82E0PFJ7ULFPplfshQDzb4nIOLKruYFD0CYWheRPMM/eVqNbNZUzc/LLrhyubsK0Q=="
     },
     "node_modules/mystjs": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/mystjs/-/mystjs-0.0.6.tgz",
-      "integrity": "sha512-pTeObgU77a3LUFqwy1W42Zxj8secaE3riK8sThQXLhQmQCvQTvqixxXZ5P5Kuda0+EjTM1sisZ9gQ0RoQr75Cg==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mystjs/-/mystjs-0.0.7.tgz",
+      "integrity": "sha512-y9le930TO0FlqOS+rAfUwiFnlEgGoLuIU0G0sA75HDeQbc3a7s/bK5JtZlcJKOirj8tvL1fuzl500xwphOsVIw==",
       "dependencies": {
         "classnames": "^2.3.1",
+        "hast-util-to-mdast": "^8.3.1",
         "he": "^1.2.0",
         "markdown-it": "^12.3.2",
         "markdown-it-amsmath": "^0.3.1",
@@ -7721,11 +7824,12 @@
         "mdast-util-to-hast": "^12.1.1",
         "myst-spec": "^0.0.4",
         "rehype-format": "^4.0.1",
+        "rehype-remark": "^9.1.2",
         "rehype-stringify": "^9.0.3",
         "unified": "^10.1.1",
         "unist-builder": "^3.0.0",
         "unist-util-find-after": "^4.0.0",
-        "unist-util-map": "^3.0.0",
+        "unist-util-map": "^3.0.1",
         "unist-util-remove": "^3.1.0",
         "unist-util-select": "^4.0.1",
         "unist-util-visit": "^4.1.0"
@@ -8957,6 +9061,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-remark": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-9.1.2.tgz",
+      "integrity": "sha512-c0fG3/CrJ95zAQ07xqHSkdpZybwdsY7X5dNWvgL2XqLKZuqmG3+vk6kP/4miCnp+R+x/0uKKRSpfXb9aGR8Z5w==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "hast-util-to-mdast": "^8.3.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-stringify": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-9.0.3.tgz",
@@ -9750,6 +9869,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/trim-trailing-lines": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.0.0.tgz",
+      "integrity": "sha512-lyJ/STqmYO8k9aWZbodPTrVkRh/50yFwNZ/HxKp/30eM9zf898MgQCG/NxfMnx7fZSKbaEcuZ1V+QgWrXFH6rg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/trough": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
@@ -10044,9 +10172,9 @@
       }
     },
     "node_modules/unist-util-map": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-3.0.0.tgz",
-      "integrity": "sha512-kyPbOAlOPZpytdyquF1g6qYpAjkpMpSPtR7TAj4SOQWSJfQ/LN+IFI2oWBvkxzhsPKxiMKZcgpp5ihZLLvNl6g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-3.0.1.tgz",
+      "integrity": "sha512-TOLoGOyT6pYI3JjTBZ1z76Rp7g+xcfgzuQDESuOUTZIkqpOIXsqZTvI25fKCYjMAmADbeulxusIgoB5IBPGZuQ==",
       "dependencies": {
         "@types/unist": "^2.0.0"
       },
@@ -11356,6 +11484,42 @@
         "prosemirror-tables": "^1.1.1",
         "prosemirror-transform": "^1.3.3",
         "prosemirror-utils": "^0.9.6"
+      },
+      "dependencies": {
+        "myst-spec": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/myst-spec/-/myst-spec-0.0.2.tgz",
+          "integrity": "sha512-jGOFSDDdYip9JsW3KPHfq7v2AC9c4Pg7gM4HEtNX2bhsHQNqldU6nZv+QmXtxIwDlfYAGVIHgQL3XNfM+7QeEg=="
+        },
+        "mystjs": {
+          "version": "https://registry.npmjs.org/mystjs/-/mystjs-0.0.5.tgz",
+          "integrity": "sha512-J+hYVwIyXN0H6/wwmANUc5rs9MdLJRcQ2ABm7sZPGidwwNSPSg105xlN4eFTxBksKh7PxIHkEWBJCxYPb42QuA==",
+          "requires": {
+            "classnames": "^2.3.1",
+            "he": "^1.2.0",
+            "markdown-it": "^12.3.2",
+            "markdown-it-amsmath": "^0.3.1",
+            "markdown-it-deflist": "^2.1.0",
+            "markdown-it-docutils": "0.1.4",
+            "markdown-it-dollarmath": "^0.4.2",
+            "markdown-it-footnote": "^3.0.3",
+            "markdown-it-front-matter": "^0.2.3",
+            "markdown-it-myst-extras": "0.2.0",
+            "markdown-it-task-lists": "^2.1.1",
+            "mdast-util-find-and-replace": "^2.1.0",
+            "mdast-util-to-hast": "^12.1.1",
+            "myst-spec": "0.0.2",
+            "rehype-format": "^4.0.1",
+            "rehype-stringify": "^9.0.3",
+            "unified": "^10.1.1",
+            "unist-builder": "^3.0.0",
+            "unist-util-find-after": "^4.0.0",
+            "unist-util-map": "^3.0.0",
+            "unist-util-remove": "^3.1.0",
+            "unist-util-select": "^4.0.1",
+            "unist-util-visit": "^4.1.0"
+          }
+        }
       }
     },
     "@eslint/eslintrc": {
@@ -11922,6 +12086,11 @@
       "resolved": "https://registry.npmjs.org/@types/copyfiles/-/copyfiles-2.4.1.tgz",
       "integrity": "sha512-v2JLxXeWUeWYWVo3/tlpxqiDCvgewSvf58HHjHYNaCi0lAthhRQ7jz8InxGzJsrMbWmWkYaxBO+BEtKjBU4ebw==",
       "dev": true
+    },
+    "@types/extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw=="
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -14507,6 +14676,37 @@
         "unist-util-is": "^5.0.0"
       }
     },
+    "hast-util-to-mdast": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-8.3.1.tgz",
+      "integrity": "sha512-nxLcom1oW5y/1CyaV24K16LOfYbAIS74BDbCPW6WduzAYTAVDp3g/DM1CY6Ngo+Dx5itLzvmCm7SnUHBZd3NVQ==",
+      "requires": {
+        "@types/extend": "^3.0.0",
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "extend": "^3.0.0",
+        "hast-util-has-property": "^2.0.0",
+        "hast-util-is-element": "^2.0.0",
+        "hast-util-to-text": "^3.0.0",
+        "mdast-util-phrasing": "^3.0.0",
+        "mdast-util-to-string": "^3.0.0",
+        "rehype-minify-whitespace": "^5.0.0",
+        "trim-trailing-lines": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit": "^4.0.0"
+      }
+    },
+    "hast-util-to-text": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-3.1.1.tgz",
+      "integrity": "sha512-7S3mOBxACy8syL45hCn3J7rHqYaXkxRfsX6LXEU5Shz4nt4GxdjtMUtG+T6G/ZLUHd7kslFAf14kAN71bz30xA==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "hast-util-is-element": "^2.0.0",
+        "unist-util-find-after": "^4.0.0"
+      }
+    },
     "hast-util-whitespace": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.0.tgz",
@@ -16126,6 +16326,15 @@
         }
       }
     },
+    "mdast-util-phrasing": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.0.tgz",
+      "integrity": "sha512-S+QYsDRLkGi8U7o5JF1agKa/sdP+CNGXXLqC17pdTVL8FHHgQEiwFGa9yE5aYtUxNiFGYoaDy9V1kC85Sz86Gg==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "unist-util-is": "^5.0.0"
+      }
+    },
     "mdast-util-to-hast": {
       "version": "12.1.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.1.1.tgz",
@@ -16142,6 +16351,11 @@
         "unist-util-position": "^4.0.0",
         "unist-util-visit": "^4.0.0"
       }
+    },
+    "mdast-util-to-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
+      "integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA=="
     },
     "mdurl": {
       "version": "1.0.1",
@@ -16270,11 +16484,12 @@
       "integrity": "sha512-1j7184Wmg5lhgSXt6AXtG82E0PFJ7ULFPplfshQDzb4nIOLKruYFD0CYWheRPMM/eVqNbNZUzc/LLrhyubsK0Q=="
     },
     "mystjs": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/mystjs/-/mystjs-0.0.6.tgz",
-      "integrity": "sha512-pTeObgU77a3LUFqwy1W42Zxj8secaE3riK8sThQXLhQmQCvQTvqixxXZ5P5Kuda0+EjTM1sisZ9gQ0RoQr75Cg==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mystjs/-/mystjs-0.0.7.tgz",
+      "integrity": "sha512-y9le930TO0FlqOS+rAfUwiFnlEgGoLuIU0G0sA75HDeQbc3a7s/bK5JtZlcJKOirj8tvL1fuzl500xwphOsVIw==",
       "requires": {
         "classnames": "^2.3.1",
+        "hast-util-to-mdast": "^8.3.1",
         "he": "^1.2.0",
         "markdown-it": "^12.3.2",
         "markdown-it-amsmath": "^0.3.1",
@@ -16289,11 +16504,12 @@
         "mdast-util-to-hast": "^12.1.1",
         "myst-spec": "^0.0.4",
         "rehype-format": "^4.0.1",
+        "rehype-remark": "^9.1.2",
         "rehype-stringify": "^9.0.3",
         "unified": "^10.1.1",
         "unist-builder": "^3.0.0",
         "unist-util-find-after": "^4.0.0",
-        "unist-util-map": "^3.0.0",
+        "unist-util-map": "^3.0.1",
         "unist-util-remove": "^3.1.0",
         "unist-util-select": "^4.0.1",
         "unist-util-visit": "^4.1.0"
@@ -17247,6 +17463,17 @@
         "unist-util-is": "^5.0.0"
       }
     },
+    "rehype-remark": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-9.1.2.tgz",
+      "integrity": "sha512-c0fG3/CrJ95zAQ07xqHSkdpZybwdsY7X5dNWvgL2XqLKZuqmG3+vk6kP/4miCnp+R+x/0uKKRSpfXb9aGR8Z5w==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "hast-util-to-mdast": "^8.3.0",
+        "unified": "^10.0.0"
+      }
+    },
     "rehype-stringify": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-9.0.3.tgz",
@@ -17852,6 +18079,11 @@
         "punycode": "^2.1.1"
       }
     },
+    "trim-trailing-lines": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.0.0.tgz",
+      "integrity": "sha512-lyJ/STqmYO8k9aWZbodPTrVkRh/50yFwNZ/HxKp/30eM9zf898MgQCG/NxfMnx7fZSKbaEcuZ1V+QgWrXFH6rg=="
+    },
     "trough": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
@@ -18034,9 +18266,9 @@
       "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
     },
     "unist-util-map": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-3.0.0.tgz",
-      "integrity": "sha512-kyPbOAlOPZpytdyquF1g6qYpAjkpMpSPtR7TAj4SOQWSJfQ/LN+IFI2oWBvkxzhsPKxiMKZcgpp5ihZLLvNl6g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-3.0.1.tgz",
+      "integrity": "sha512-TOLoGOyT6pYI3JjTBZ1z76Rp7g+xcfgzuQDESuOUTZIkqpOIXsqZTvI25fKCYjMAmADbeulxusIgoB5IBPGZuQ==",
       "requires": {
         "@types/unist": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "katex": "^0.15.2",
     "lodash.throttle": "^4.1.1",
     "mime-types": "^2.1.35",
+    "myst-spec": "^0.0.4",
     "mystjs": "^0.0.6",
     "nanoid": "^3.3.2",
     "node-fetch": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lodash.throttle": "^4.1.1",
     "mime-types": "^2.1.35",
     "myst-spec": "^0.0.4",
-    "mystjs": "^0.0.6",
+    "mystjs": "^0.0.7",
     "nanoid": "^3.3.2",
     "node-fetch": "^2.6.7",
     "p-limit": "^3.1.0",

--- a/src/actions/getChildren.ts
+++ b/src/actions/getChildren.ts
@@ -1,9 +1,10 @@
 import { VersionId } from '@curvenote/blocks';
 import { Block, Version } from '../models';
 import { ISession } from '../session/types';
+import { versionIdToURL } from '../utils';
 
 export async function getChildren(session: ISession, versionId: VersionId) {
-  const url = `/blocks/${versionId.project}/${versionId.block}/versions/${versionId.version}/children`;
+  const url = `${versionIdToURL(versionId)}/children`;
   session.log.debug(`Fetching version children: ${url}`);
   const { status, json } = await session.get(url);
   if (status !== 200) throw new Error('Could not get children');

--- a/src/models.ts
+++ b/src/models.ts
@@ -29,6 +29,7 @@ import {
   selectVersion,
   selectTemplate,
 } from './store/selectors';
+import { versionIdToURL } from './utils';
 
 export class MyUser extends BaseTransfer<string, MyUserDTO> {
   constructor(session: ISession) {
@@ -105,7 +106,7 @@ export class Version<T extends ALL_BLOCKS = ALL_BLOCKS> extends BaseTransfer<
 
   $fromDTO = versionFromDTO as (versionId: VersionId, json: JsonObject) => T;
 
-  $createUrl = () => `/blocks/${this.id.project}/${this.id.block}/versions/${this.id.version}`;
+  $createUrl = () => versionIdToURL(this.id);
 
   $recieve = versions.actions.recieve;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { VersionId } from '@curvenote/blocks';
 import fs from 'fs';
 import path from 'path';
 
@@ -13,4 +14,8 @@ export function writeFileToFolder(
   } else {
     writeFileToFolder(path.join(filename.path || '.', filename.filename), data, opts);
   }
+}
+
+export function versionIdToURL(versionId: VersionId) {
+  return `/blocks/${versionId.project}/${versionId.block}/versions/${versionId.version}`;
 }

--- a/src/web/cache.ts
+++ b/src/web/cache.ts
@@ -17,7 +17,7 @@ import { IDocumentCache, Options, SiteConfig } from './types';
 import { parseMyst, publicPath, serverPath } from './utils';
 
 import { LinkLookup, RendererData, transformLinks, transformMdast } from './transforms';
-import { copyImages, readConfig } from './webConfig';
+import { readConfig } from './webConfig';
 import { createWebFileObjectFactory } from './files';
 import { writeFileToFolder } from '../utils';
 
@@ -25,12 +25,12 @@ type NextFile = { filename: string; folder: string; slug: string };
 
 async function processMarkdown(
   cache: IDocumentCache,
-  filename: { from: string; to: string },
+  filename: { from: string; to: string; folder: string },
   content: string,
   citeRenderer: CitationRenderer,
 ) {
   const mdast = parseMyst(content);
-  const data = await transformMdast(cache, filename.from, mdast, citeRenderer);
+  const data = await transformMdast(cache, filename, mdast, citeRenderer);
   return data;
 }
 
@@ -45,7 +45,7 @@ function createOutputDirective(): { myst: string; id: string } {
 
 async function processNotebook(
   cache: IDocumentCache,
-  filename: { from: string; to: string },
+  filename: { from: string; to: string; folder: string },
   content: string,
   citeRenderer: CitationRenderer,
 ) {
@@ -98,7 +98,7 @@ async function processNotebook(
     output.data = outputMap[output.id];
   });
 
-  const data = await transformMdast(cache, filename.from, mdast, citeRenderer);
+  const data = await transformMdast(cache, filename, mdast, citeRenderer);
   return data;
 }
 
@@ -275,9 +275,6 @@ export class DocumentCache implements IDocumentCache {
       this.config = config;
     } catch (error) {
       this.session.log.error(`Error reading config:\n\n${(error as Error).message}`);
-    }
-    if (this.config) {
-      await copyImages(this.session, this.options, this.config);
     }
   }
 

--- a/src/web/transforms/images.ts
+++ b/src/web/transforms/images.ts
@@ -1,19 +1,83 @@
+import { oxaLinkToId, VersionId } from '@curvenote/blocks';
 import { GenericNode, selectAll } from 'mystjs';
+import fetch from 'node-fetch';
+import fs from 'fs';
 import path from 'path';
+import mime from 'mime-types';
 
-import { Root } from './types';
+import { Root, TransformState } from './types';
+import { Options } from '../types';
 
-export function transformImages(mdast: Root) {
+export function serverPath(opts: Options) {
+  const buildPath = opts.buildPath || '_build';
+  return `${buildPath}/web`;
+}
+
+export function publicPath(opts: Options) {
+  return path.join(serverPath(opts), 'public');
+}
+
+export function imagePath(opts: Options) {
+  return path.join(publicPath(opts), '_static');
+}
+
+export async function transformImages(mdast: Root, state: TransformState) {
   const images = selectAll('image', mdast) as GenericNode[];
-  images.forEach((image) => {
-    // leave urls alone
-    if (
-      image.url.toLowerCase().startsWith('http:') ||
-      image.url.toLowerCase().startsWith('https:')
-    ) {
-      return;
-    }
-    // assumes all images referenced in myst content are moved to public/_static
-    image.url = `/_static/${path.basename(image.url)}`;
-  });
+  await Promise.all(
+    images.map(async (image) => {
+      const oxa = oxaLinkToId(image.url);
+      const isUrl =
+        image.url.toLowerCase().startsWith('http:') || image.url.toLowerCase().startsWith('https:');
+      // Leave non-oxa URLs alone
+      if (!oxa && isUrl) return;
+      // Assume remaining non-oxa paths are local images
+      if (!oxa) {
+        image.url = `/_static/${path.basename(image.url)}`;
+        return;
+      }
+      // Otherwise, fetch oxa image and save locally
+      const versionId = oxa?.block as VersionId;
+      if (!versionId?.version) return;
+      const url = `/blocks/${versionId.project}/${versionId.block}/versions/${versionId.version}`;
+      const session = state.cache.session;
+      session.log.debug(`Fetching image version: ${url}`);
+      const { status, json } = await session.get(url);
+      const downloadUrl = json.links?.download;
+      if (status !== 200 || !downloadUrl) {
+        session.log.debug(`Error fetching image version: ${url}`);
+        return;
+      }
+      let extension: string | false = path.extname(json.file_name || '').slice(1);
+      if (!extension && json.content_type) {
+        const contentType = mime.contentType(json.content_type);
+        if (contentType) {
+          extension = mime.extension(contentType);
+        }
+      }
+      if (!extension) {
+        session.log.debug(`Cannot determine content type of: ${url}`);
+        return;
+      }
+      const file = `${versionId.block}.${versionId.version}.${extension}`;
+      const filePath = path.join(imagePath(state.cache.options), file);
+      session.log.debug(
+        `Fetching image: ${downloadUrl.slice(0, 31)}...\n  -> saving to: ${filePath}`,
+      );
+      await fetch(downloadUrl)
+        .then(
+          (res) =>
+            new Promise((resolve, reject) => {
+              const fileStream = fs.createWriteStream(filePath);
+              res.body.pipe(fileStream);
+              res.body.on('error', reject);
+              fileStream.on('finish', resolve);
+            }),
+        )
+        .then(() => {
+          image.url = `/_static/${file}`;
+          session.log.debug(`Image successfully saved to: ${filePath}`);
+        })
+        .catch(() => session.log.debug(`Error saving image to: ${filePath}`));
+    }),
+  );
 }

--- a/src/web/transforms/images.ts
+++ b/src/web/transforms/images.ts
@@ -6,6 +6,13 @@ import { Root } from './types';
 export function transformImages(mdast: Root) {
   const images = selectAll('image', mdast) as GenericNode[];
   images.forEach((image) => {
+    // leave urls alone
+    if (
+      image.url.toLowerCase().startsWith('http:') ||
+      image.url.toLowerCase().startsWith('https:')
+    ) {
+      return;
+    }
     // assumes all images referenced in myst content are moved to public/_static
     image.url = `/_static/${path.basename(image.url)}`;
   });

--- a/src/web/transforms/index.ts
+++ b/src/web/transforms/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import { CitationRenderer } from 'citation-js-utils';
-import { GenericNode, selectAll } from 'mystjs';
+import { convertHtmlToMdast, GenericNode, selectAll } from 'mystjs';
 import { IDocumentCache } from '../types';
 import { transformRoot } from './root';
 import { transformMath } from './math';
@@ -68,6 +68,7 @@ export async function transformMdast(
   // The transforms from MyST (structural mostly)
   mdast = await transformRoot(mdast);
   [
+    convertHtmlToMdast,
     transformMath,
     transformImages,
     transformOutputs,

--- a/src/web/transforms/index.ts
+++ b/src/web/transforms/index.ts
@@ -67,10 +67,10 @@ export async function transformMdast(
   importMdastFromJson(cache, name, mdast); // This must be first!
   // The transforms from MyST (structural mostly)
   mdast = await transformRoot(mdast);
+  convertHtmlToMdast(mdast);
+  cache.session.log.debug(toc(`Processing: "${name}" - html in %s`));
   [
-    convertHtmlToMdast,
     transformMath,
-    transformImages,
     transformOutputs,
     transformCitations,
     transformEnumerators,
@@ -83,6 +83,10 @@ export async function transformMdast(
       toc(`Processing: "${name}" - ${transformer.name.slice(9).toLowerCase()} in %s`),
     );
   });
+
+  await transformImages(mdast, { references, citeRenderer, cache, frontmatter });
+  cache.session.log.debug(toc(`Processing: "${name}" - images in %s`));
+
   if (cache.config?.site?.design?.hideAuthors) {
     delete frontmatter.authors;
   }

--- a/src/web/transforms/index.ts
+++ b/src/web/transforms/index.ts
@@ -15,6 +15,7 @@ import { Frontmatter, getFrontmatter } from '../frontmatter';
 import { References, Root } from './types';
 import { tic } from '../../export/utils/exec';
 
+export { imagePath, publicPath, serverPath } from './images';
 export { LinkLookup, transformLinks } from './links';
 
 export interface RendererData {

--- a/src/web/transforms/index.ts
+++ b/src/web/transforms/index.ts
@@ -55,7 +55,7 @@ function importMdastFromJson(cache: IDocumentCache, filename: string, mdast: Roo
 
 export async function transformMdast(
   cache: IDocumentCache,
-  name: string,
+  filename: { from: string; folder: string },
   mdast: Root,
   citeRenderer: CitationRenderer,
 ): Promise<Omit<RendererData, 'sha256'>> {
@@ -64,6 +64,7 @@ export async function transformMdast(
     cite: { order: [], data: {} },
     footnotes: {},
   };
+  const { from: name, folder } = filename;
   const frontmatter = getFrontmatter(mdast);
   importMdastFromJson(cache, name, mdast); // This must be first!
   // The transforms from MyST (structural mostly)
@@ -79,13 +80,13 @@ export async function transformMdast(
     transformFootnotes,
     transformKeys,
   ].forEach((transformer) => {
-    transformer(mdast, { references, citeRenderer, cache, frontmatter });
+    transformer(mdast, { references, citeRenderer, cache, frontmatter, folder });
     cache.session.log.debug(
       toc(`Processing: "${name}" - ${transformer.name.slice(9).toLowerCase()} in %s`),
     );
   });
 
-  await transformImages(mdast, { references, citeRenderer, cache, frontmatter });
+  await transformImages(mdast, { references, citeRenderer, cache, frontmatter, folder });
   cache.session.log.debug(toc(`Processing: "${name}" - images in %s`));
 
   if (cache.config?.site?.design?.hideAuthors) {

--- a/src/web/transforms/types.ts
+++ b/src/web/transforms/types.ts
@@ -23,4 +23,5 @@ export type TransformState = {
   references: References;
   citeRenderer: CitationRenderer;
   cache: IDocumentCache;
+  folder: string;
 };

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -1,19 +1,12 @@
 import fs from 'fs';
-import path from 'path';
 import { MyST } from 'mystjs';
 import { Options } from './types';
 import { reactiveRoles } from './roles';
 import { directives } from './directives';
 import { Root } from './transforms/types';
+import { serverPath } from './transforms/images';
 
-export function serverPath(opts: Options) {
-  const buildPath = opts.buildPath || '_build';
-  return `${buildPath}/web`;
-}
-
-export function publicPath(opts: Options) {
-  return path.join(serverPath(opts), 'public');
-}
+export { serverPath, publicPath } from './transforms/images';
 
 export function exists(opts: Options) {
   return fs.existsSync(serverPath(opts));

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -4,9 +4,9 @@ import { Options } from './types';
 import { reactiveRoles } from './roles';
 import { directives } from './directives';
 import { Root } from './transforms/types';
-import { serverPath } from './transforms/images';
+import { serverPath } from './transforms';
 
-export { serverPath, publicPath } from './transforms/images';
+export { serverPath, publicPath } from './transforms';
 
 export function exists(opts: Options) {
   return fs.existsSync(serverPath(opts));

--- a/src/web/webConfig.ts
+++ b/src/web/webConfig.ts
@@ -6,7 +6,7 @@ import { ISession } from '../session/types';
 import { JupyterBookChapter, readTOC } from '../export/jupyter-book/toc';
 import { tic } from '../export/utils/exec';
 import { Options, Page, SiteConfig, SiteFolder } from './types';
-import { publicPath } from './utils';
+import { publicPath, imagePath } from './transforms';
 import { CURVENOTE_YML } from '../config';
 
 export function getFileName(folder: string, file: string) {
@@ -169,7 +169,7 @@ export async function copyImages(session: ISession, opts: Options, config: SiteC
       return new Promise((callback, error) => {
         // TODO this 'from' path needs to be read from curvenote.yml#sync
         const from = path.join(p, 'images', '*');
-        const to = path.join(publicPath(opts), '_static');
+        const to = imagePath(opts);
         session.log.debug(`Copying images from "${from}" to "${to}"`);
         copyfiles([from, to], { up: true, soft: true } as any, (e) => {
           if (e) {

--- a/src/web/webConfig.ts
+++ b/src/web/webConfig.ts
@@ -1,12 +1,10 @@
-import copyfiles from 'copyfiles';
 import fs from 'fs';
 import path from 'path';
 import { WebConfig } from '../config/types';
 import { ISession } from '../session/types';
 import { JupyterBookChapter, readTOC } from '../export/jupyter-book/toc';
-import { tic } from '../export/utils/exec';
 import { Options, Page, SiteConfig, SiteFolder } from './types';
-import { publicPath, imagePath } from './transforms';
+import { publicPath } from './transforms';
 import { CURVENOTE_YML } from '../config';
 
 export function getFileName(folder: string, file: string) {
@@ -160,29 +158,6 @@ function createConfig(session: ISession, opts: Options): Required<SiteConfig> {
     site,
     folders,
   };
-}
-
-export async function copyImages(session: ISession, opts: Options, config: SiteConfig) {
-  const toc = tic();
-  await Promise.all(
-    config.site.sections.map(async ({ path: p }) => {
-      return new Promise((callback, error) => {
-        // TODO this 'from' path needs to be read from curvenote.yml#sync
-        const from = path.join(p, 'images', '*');
-        const to = imagePath(opts);
-        session.log.debug(`Copying images from "${from}" to "${to}"`);
-        copyfiles([from, to], { up: true, soft: true } as any, (e) => {
-          if (e) {
-            session.log.error(e.message);
-            error();
-          } else {
-            callback(true);
-          }
-        });
-      });
-    }),
-  );
-  session.log.info(toc(`🌄 Copied images in %s.`));
 }
 
 export async function readConfig(session: ISession, opts: Options): Promise<SiteConfig> {


### PR DESCRIPTION
This works to address #56 

- [x] HTML images need to be rendered
  - **NOTE:** this was done by transforming all `html` nodes to `mdast`, so it will have wider-reaching effects than images. This may be a good thing (i.e. work to resolve #55) or a bad thing (cause unsafe, unwanted behavior).
- [x] Images from URLs render
  - These are now downloaded and cached when running `curvenote start`. Another valid option would be to leave the original URL and not overwrite with a CDN url.
- [x] Images from oxa links render
  - These are now correctly downloaded/cached/referenced
- [x] Local images no longer need to be moved to `images/` folder, local paths are respected

Takes us from:
![image](https://user-images.githubusercontent.com/9453731/164394139-e36d0476-9a2c-4420-8138-e8ae936de80e.png)

to:
![image](https://user-images.githubusercontent.com/9453731/164393593-f3424ab1-ec8e-4d51-bd08-bca10564b077.png)
