### PR TITLE
Add transform to nest un-blocked md in a block

### DIFF
--- a/src/web/transforms/blocks.ts
+++ b/src/web/transforms/blocks.ts
@@ -1,0 +1,9 @@
+import { GenericNode, select } from 'mystjs';
+import { Root } from './types';
+
+export function ensureBlockNesting(mdast: Root) {
+  if (!select('block', mdast)) {
+    const blockNode = { type: 'block', children: mdast.children as GenericNode[] };
+    (mdast as GenericNode).children = [blockNode];
+  }
+}


### PR DESCRIPTION
This resolves #62 

Rather than modifying the md with `+++` as suggested in the issue, this just passes the mdast through a transform that nests everything in a `block` node if no other `block` nodes are present.

![image](https://user-images.githubusercontent.com/9453731/164875748-fff6734e-bb51-4213-8bbf-e8d115f7a00b.png)




Unrelated, but this also adds an html-to-mdast-transform handler for comments like this so they don't show up in curvespace:

![image](https://user-images.githubusercontent.com/9453731/164875556-234a4d31-c8a0-407b-a411-85f6bdf7e46f.png)

(upstreamed to mystjs too: https://github.com/executablebooks/mystjs/commit/e9320df9068d8ade41e515c2f753c0348dd4b673 )