### PR TITLE
Config validation

### DIFF
--- a/src/cli/token.ts
+++ b/src/cli/token.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { deleteToken, setToken } from '../session';
-import { anonSession, clirun } from './utils';
+import { clirun } from './utils';
 
 export function addTokenCLI(program: Command) {
   const command = new Command('token').description(
@@ -12,7 +12,7 @@ export function addTokenCLI(program: Command) {
     .action(
       clirun(async (session, token?: string) => setToken(session.log, token), {
         program,
-        session: anonSession(program.opts()),
+        anonymous: true,
       }),
     );
   command
@@ -22,7 +22,7 @@ export function addTokenCLI(program: Command) {
     .action(
       clirun((session) => deleteToken(session.log), {
         program,
-        session: anonSession(program.opts()),
+        anonymous: true,
       }),
     );
   program.addCommand(command);

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -88,15 +88,16 @@ export function clirun(
     | ((session: ISession, ...args: any[]) => void),
   cli: {
     program: Command;
-    session?: ISession;
+    anonymous?: boolean;
     requireSiteConfig?: boolean;
     hideNoTokenWarning?: boolean;
   },
 ) {
   return async (...args: any[]) => {
     const opts = cli.program.opts() as SessionOpts;
-    const useSession =
-      cli.session ?? getSession({ ...opts, hideNoTokenWarning: cli.hideNoTokenWarning });
+    const useSession = cli.anonymous
+      ? anonSession(opts)
+      : getSession({ ...opts, hideNoTokenWarning: cli.hideNoTokenWarning });
     const versionsInstalled = await checkNodeVersion(useSession);
     if (!versionsInstalled) process.exit(1);
     const config = selectors.selectLocalSiteConfig(useSession.store.getState());

--- a/src/config/config.spec.ts
+++ b/src/config/config.spec.ts
@@ -28,10 +28,6 @@ describe('validateProjectConfig', () => {
     };
     expect(validateProjectConfig(projConfig, opts)).toEqual(projConfig);
   });
-  it('invalid remote url errors', async () => {
-    expect(validateProjectConfig({ remote: 'https://example.com' }, opts)).toEqual({});
-    expect(opts.count.errors).toEqual(1);
-  });
   it('invalid exclude omitted', async () => {
     expect(validateProjectConfig({ exclude: ['license.md', 5] }, opts)).toEqual({
       exclude: ['license.md'],
@@ -204,6 +200,15 @@ describe('validateSiteConfig', () => {
   it('missing required values are coerced', async () => {
     expect(validateSiteConfig({}, opts)).toEqual({
       projects: [],
+      nav: [],
+      actions: [],
+      domains: [],
+    });
+    expect(opts.count.errors).toEqual(1);
+  });
+  it('valid required values are not coerced', async () => {
+    expect(validateSiteConfig({ projects: [{ path: 'my-proj', slug: 'test' }] }, opts)).toEqual({
+      projects: [{ path: 'my-proj', slug: 'test' }],
       nav: [],
       actions: [],
       domains: [],

--- a/src/config/config.spec.ts
+++ b/src/config/config.spec.ts
@@ -145,10 +145,6 @@ describe('validateSiteAnalytics', () => {
 });
 
 describe('validateSiteConfig', () => {
-  it('empty object errors', async () => {
-    expect(validateSiteConfig({}, opts)).toEqual(undefined);
-    expect(opts.count.errors).toEqual(1);
-  });
   it('valid site config returns self', async () => {
     const siteConfig = {
       projects: [{ path: 'my-proj', slug: 'test' }],
@@ -189,7 +185,7 @@ describe('validateSiteConfig', () => {
     });
     expect(opts.count.errors).toEqual(4);
   });
-  it('invalid list values are filtered', async () => {
+  it('invalid required values error', async () => {
     expect(
       validateSiteConfig(
         {
@@ -203,6 +199,15 @@ describe('validateSiteConfig', () => {
         opts,
       ),
     ).toEqual(undefined);
+    expect(opts.count.errors).toEqual(1);
+  });
+  it('missing required values are coerced', async () => {
+    expect(validateSiteConfig({}, opts)).toEqual({
+      projects: [],
+      nav: [],
+      actions: [],
+      domains: [],
+    });
     expect(opts.count.errors).toEqual(1);
   });
 });

--- a/src/config/config.spec.ts
+++ b/src/config/config.spec.ts
@@ -1,0 +1,22 @@
+import { basicLogger, LogLevel } from '../logging';
+import { validateProjectConfig } from './validators';
+
+const opts = { logger: basicLogger(LogLevel.info), property: 'test' };
+
+describe('validateProjectConfig', () => {
+  it('empty object returns self', async () => {
+    expect(validateProjectConfig({}, opts)).toEqual({});
+  });
+  it('valid project config returns self', async () => {
+    const projConfig = {
+      title: 'example',
+      remote: 'https://curvenote.com/@test/project',
+      index: 'folder/readme.md',
+      exclude: ['license.md'],
+    };
+    expect(validateProjectConfig(projConfig, opts)).toEqual(projConfig);
+  });
+  it('invalid remote url errors', async () => {
+    expect(() => validateProjectConfig({ remote: 'https://example.com' }, opts)).toThrow();
+  });
+});

--- a/src/config/config.spec.ts
+++ b/src/config/config.spec.ts
@@ -3,6 +3,9 @@ import { Options } from '../utils/validators';
 import {
   validateProjectConfig,
   validateSiteAction,
+  validateSiteAnalytics,
+  validateSiteConfig,
+  validateSiteDesign,
   validateSiteNavItem,
   validateSiteProject,
 } from './validators';
@@ -112,6 +115,94 @@ describe('validateSiteAction', () => {
   });
   it('invalid url errors', async () => {
     expect(validateSiteAction({ title: 'example', url: '/a' }, opts)).toEqual(undefined);
+    expect(opts.count.errors).toEqual(1);
+  });
+});
+
+describe('validateSiteDesign', () => {
+  it('empty object returns self', async () => {
+    expect(validateSiteDesign({}, opts)).toEqual({});
+  });
+  it('valid site design returns self', async () => {
+    const siteDesign = {
+      hide_authors: true,
+    };
+    expect(validateSiteDesign(siteDesign, opts)).toEqual(siteDesign);
+  });
+});
+
+describe('validateSiteAnalytics', () => {
+  it('empty object returns self', async () => {
+    expect(validateSiteAnalytics({}, opts)).toEqual({});
+  });
+  it('valid site design returns self', async () => {
+    const siteAnalytics = {
+      google: 'google',
+      plausible: 'plausible',
+    };
+    expect(validateSiteAnalytics(siteAnalytics, opts)).toEqual(siteAnalytics);
+  });
+});
+
+describe('validateSiteConfig', () => {
+  it('empty object errors', async () => {
+    expect(validateSiteConfig({}, opts)).toEqual(undefined);
+    expect(opts.count.errors).toEqual(1);
+  });
+  it('valid site config returns self', async () => {
+    const siteConfig = {
+      projects: [{ path: 'my-proj', slug: 'test' }],
+      nav: [{ title: 'cool folder', children: [{ title: 'cool page', url: '/test/cool-page' }] }],
+      actions: [{ title: 'Go To Example', url: 'https://example.com', static: false }],
+      domains: ['test.curve.space'],
+      twitter: 'test',
+      logo: 'curvenote.png',
+      logoText: 'test logo',
+      favicon: 'curvenote.png',
+      buildPath: '_build',
+      analytics: {
+        google: 'google',
+        plausible: 'plausible',
+      },
+      design: {
+        hide_authors: true,
+      },
+    };
+    expect(validateSiteConfig(siteConfig, opts)).toEqual(siteConfig);
+  });
+  it('invalid list values are filtered', async () => {
+    expect(
+      validateSiteConfig(
+        {
+          projects: [{ path: 'my-proj', slug: '/my/proj' }],
+          nav: [{ title: 'cool folder', children: 'a' }],
+          actions: [{ title: 'Go To Example', url: '/my/proj', static: false }],
+          domains: ['example.com'],
+        },
+        opts,
+      ),
+    ).toEqual({
+      projects: [],
+      nav: [],
+      actions: [],
+      domains: [],
+    });
+    expect(opts.count.errors).toEqual(4);
+  });
+  it('invalid list values are filtered', async () => {
+    expect(
+      validateSiteConfig(
+        {
+          projects: 'a',
+          nav: [
+            { title: 'cool folder', children: [{ title: 'cool page', url: '/test/cool-page' }] },
+          ],
+          actions: [{ title: 'Go To Example', url: 'https://example.com', static: false }],
+          domains: ['test.curve.space'],
+        },
+        opts,
+      ),
+    ).toEqual(undefined);
     expect(opts.count.errors).toEqual(1);
   });
 });

--- a/src/config/config.spec.ts
+++ b/src/config/config.spec.ts
@@ -1,7 +1,17 @@
 import { basicLogger, LogLevel } from '../logging';
-import { validateProjectConfig } from './validators';
+import { Options } from '../utils/validators';
+import {
+  validateProjectConfig,
+  validateSiteAction,
+  validateSiteNavItem,
+  validateSiteProject,
+} from './validators';
 
-const opts = { logger: basicLogger(LogLevel.info), property: 'test' };
+let opts: Options;
+
+beforeEach(() => {
+  opts = { logger: basicLogger(LogLevel.info), property: 'test', count: {} };
+});
 
 describe('validateProjectConfig', () => {
   it('empty object returns self', async () => {
@@ -9,7 +19,6 @@ describe('validateProjectConfig', () => {
   });
   it('valid project config returns self', async () => {
     const projConfig = {
-      title: 'example',
       remote: 'https://curvenote.com/@test/project',
       index: 'folder/readme.md',
       exclude: ['license.md'],
@@ -17,6 +26,92 @@ describe('validateProjectConfig', () => {
     expect(validateProjectConfig(projConfig, opts)).toEqual(projConfig);
   });
   it('invalid remote url errors', async () => {
-    expect(() => validateProjectConfig({ remote: 'https://example.com' }, opts)).toThrow();
+    expect(validateProjectConfig({ remote: 'https://example.com' }, opts)).toEqual({});
+    expect(opts.count.errors).toEqual(1);
+  });
+  it('invalid exclude omitted', async () => {
+    expect(validateProjectConfig({ exclude: ['license.md', 5] }, opts)).toEqual({
+      exclude: ['license.md'],
+    });
+    expect(opts.count.errors).toEqual(1);
+  });
+});
+
+describe('validateSiteProject', () => {
+  it('empty object errors', async () => {
+    expect(validateSiteProject({}, opts)).toEqual(undefined);
+    expect(opts.count.errors).toEqual(1);
+  });
+  it('valid site project returns self', async () => {
+    const siteProj = {
+      path: 'my-dir',
+      slug: 'proj',
+    };
+    expect(validateSiteProject(siteProj, opts)).toEqual(siteProj);
+  });
+  it('invalid slug errors', async () => {
+    expect(validateSiteProject({ path: 'my-dir', slug: '#' }, opts)).toEqual(undefined);
+    expect(opts.count.errors).toEqual(1);
+  });
+});
+
+describe('validateSiteNavItem', () => {
+  it('empty object errors', async () => {
+    expect(validateSiteNavItem({}, opts)).toEqual(undefined);
+    expect(opts.count.errors).toEqual(1);
+  });
+  it('valid site nav folder returns self', async () => {
+    const siteNavFolder = {
+      title: 'my-folder',
+      children: [],
+    };
+    expect(validateSiteNavItem(siteNavFolder, opts)).toEqual(siteNavFolder);
+  });
+  it('valid site nav page returns self', async () => {
+    const siteNavPage = {
+      title: 'my-folder',
+      url: '/my-folder',
+    };
+    expect(validateSiteNavItem(siteNavPage, opts)).toEqual(siteNavPage);
+  });
+  it('invalid children errors', async () => {
+    expect(validateSiteNavItem({ title: 'my-folder', children: 'a' }, opts)).toEqual(undefined);
+    expect(opts.count.errors).toEqual(1);
+  });
+  it('invalid child errors', async () => {
+    expect(validateSiteNavItem({ title: 'my-folder', children: ['a'] }, opts)).toEqual({
+      title: 'my-folder',
+      children: [],
+    });
+    expect(opts.count.errors).toEqual(1);
+  });
+  it('invalid url errors', async () => {
+    expect(validateSiteNavItem({ title: 'my-folder', url: '/a/a/a' }, opts)).toEqual(undefined);
+    expect(opts.count.errors).toEqual(1);
+  });
+  it('invalid full url errors', async () => {
+    expect(
+      validateSiteNavItem({ title: 'my-folder', url: 'https://example.com/a/a' }, opts),
+    ).toEqual(undefined);
+    expect(opts.count.errors).toEqual(1);
+  });
+});
+
+describe('validateSiteAction', () => {
+  it('empty object errors', async () => {
+    expect(validateSiteAction({}, opts)).toEqual(undefined);
+    expect(opts.count.errors).toEqual(1);
+  });
+  it('valid site project returns self', async () => {
+    const siteAction = {
+      title: 'example',
+      url: 'https://example.com',
+      static: false,
+    };
+    expect(validateSiteAction(siteAction, opts)).toEqual(siteAction);
+  });
+  it('invalid url errors', async () => {
+    expect(validateSiteAction({ title: 'example', url: '/a' }, opts)).toEqual(undefined);
+    expect(opts.count.errors).toEqual(1);
   });
 });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import { join } from 'path';
 import yaml from 'js-yaml';
+import { licensesToString } from '../licenses/validators';
 import { ISession } from '../session/types';
 import { selectors } from '../store';
 import { config } from '../store/local';
@@ -12,7 +13,7 @@ import {
   validateObject,
   validationError,
 } from '../utils/validators';
-import { Config, CURVENOTE_YML, ProjectConfig, SiteConfig, VERSION } from './types';
+import { Config, CURVENOTE_YML, VERSION } from './types';
 import { validateProjectConfig, validateSiteConfig } from './validators';
 
 function emptyConfig(): Config {
@@ -133,8 +134,8 @@ export function writeConfigs(
   session: PartialSession,
   path: string,
   newConfigs?: {
-    siteConfig?: SiteConfig;
-    projectConfig?: ProjectConfig;
+    siteConfig?: Record<string, any>;
+    projectConfig?: Record<string, any>;
   },
 ) {
   // TODO: siteConfig -> rawSiteConfig before writing, don't lose extra keys in raw.
@@ -151,6 +152,9 @@ export function writeConfigs(
   // Get project config to save
   if (projectConfig) validateProjectConfigAndSave(session, path, projectConfig);
   projectConfig = selectors.selectLocalProjectConfig(state, path);
+  if (projectConfig?.licenses) {
+    projectConfig.licenses = licensesToString(projectConfig.licenses);
+  }
   // Return early if nothing new to save
   if (!siteConfig && !projectConfig) {
     session.log.debug(`No new config to write to ${file}`);

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -30,25 +30,27 @@ export type SiteAction = SiteNavPage & {
   static?: boolean;
 };
 
-export type AnalyticsConfig = {
+export type SiteAnalytics = {
   google?: string;
   plausible?: string;
 };
 
+export type SiteDesign = {
+  hide_authors?: boolean;
+};
+
 export type SiteConfig = SiteFrontmatter & {
-  twitter?: string;
-  domains: string[];
-  logo?: string | null;
-  logoText?: string;
-  favicon?: string;
-  buildPath?: string;
-  design?: {
-    hide_authors?: boolean;
-  };
   projects: SiteProject[];
   nav: SiteNavItem[];
   actions: SiteAction[];
-  analytics?: AnalyticsConfig;
+  domains: string[];
+  twitter?: string;
+  logo?: string;
+  logoText?: string;
+  favicon?: string;
+  buildPath?: string;
+  analytics?: SiteAnalytics;
+  design?: SiteDesign;
 };
 
 export type Config = {

--- a/src/config/validators.ts
+++ b/src/config/validators.ts
@@ -215,7 +215,8 @@ export function validateSiteConfigKeys(value: Record<string, any>, opts: Options
 }
 
 export function validateSiteConfig(input: any, opts: Options) {
-  const value = validateObjectKeys(input, SITE_CONFIG_KEYS, opts) || {};
+  const value =
+    validateObjectKeys(input, SITE_CONFIG_KEYS, { ...opts, returnInvalidPartial: true }) || {};
   const siteConfig = validateSiteConfigKeys(value, opts);
   return siteConfig;
 }

--- a/src/config/validators.ts
+++ b/src/config/validators.ts
@@ -1,46 +1,202 @@
-import { PROJECT_FRONTMATTER_KEYS, validateProjectFrontmatter } from '../frontmatter/validators';
+import { PROJECT_FRONTMATTER_KEYS, SITE_FRONTMATTER_KEYS } from '../frontmatter/validators';
 import {
   defined,
   incrementOptions,
   Options,
-  validateObject,
   validateKeys,
+  validateObject,
+  validateObjectKeys,
   validateString,
   validateUrl,
   validateList,
+  validateBoolean,
 } from '../utils/validators';
-import { ProjectConfig } from './types';
+import {
+  ProjectConfig,
+  SiteAction,
+  SiteAnalytics,
+  SiteConfig,
+  SiteDesign,
+  SiteNavFolder,
+  SiteNavItem,
+  SiteNavPage,
+  SiteProject,
+} from './types';
 
-const PROJECT_CONFIG_KEYS = ['remote', 'index', 'exclude'].concat(PROJECT_FRONTMATTER_KEYS);
+const PROJECT_CONFIG_KEYS = {
+  optional: ['remote', 'index', 'exclude'].concat(PROJECT_FRONTMATTER_KEYS),
+};
+const SITE_CONFIG_KEYS = {
+  required: ['projects', 'nav', 'actions', 'domains'],
+  optional: ['twitter', 'logo', 'logoText', 'favicon', 'buildPath', 'analytics', 'design'].concat(
+    SITE_FRONTMATTER_KEYS,
+  ),
+};
 
-/**
- * Validate ProjectConfig object against the schema
- */
-export function validateProjectConfig(input: any, opts: Options) {
-  const projectFrontmatter = validateProjectFrontmatter(input, { ...opts, warn: false });
-  let value = validateObject(input, opts);
-  value = validateKeys(value, { optional: PROJECT_CONFIG_KEYS }, opts);
+function validateProjectConfigKeys(value: Record<string, any>, opts: Options) {
+  const output: ProjectConfig = {};
   if (defined(value.remote)) {
-    value.remote = validateUrl(value.remote, {
+    output.remote = validateUrl(value.remote, {
       includes: 'curvenote.com',
       ...incrementOptions('remote', opts),
     });
   }
   if (defined(value.index)) {
     // TODO: Warn if these files don't exist
-    value.index = validateString(value.index, incrementOptions('index', opts));
+    output.index = validateString(value.index, incrementOptions('index', opts));
   }
   if (defined(value.exclude)) {
-    const excludeOpts = incrementOptions('exclude', opts);
-    value.exclude = validateList(value.exclude, excludeOpts).map((file) => {
-      return validateString(file, excludeOpts);
-    });
+    output.exclude = validateList(
+      value.exclude,
+      incrementOptions('exclude', opts),
+      (file, index: number) => {
+        return validateString(file, incrementOptions(`exclude.${index}`, opts));
+      },
+    );
   }
-  return { ...projectFrontmatter, ...value } as ProjectConfig;
+  return output;
 }
 
-function validateSiteProject(input: any, opts: Options) {}
-function validateSiteNavItem(input: any, opts: Options) {}
-function validateSiteAction(input: any, opts: Options) {}
-function validateSiteConfig(input: any, opts: Options) {}
-function validateConfig(input: any, opts: Options) {}
+/**
+ * Validate ProjectConfig object against the schema
+ */
+export function validateProjectConfig(input: any, opts: Options) {
+  const value = validateObjectKeys(input, PROJECT_CONFIG_KEYS, opts) || {};
+  const projectConfig = validateProjectConfigKeys(value, opts);
+  return projectConfig as ProjectConfig;
+}
+
+export function validateSiteProject(input: any, opts: Options) {
+  const value = validateObjectKeys(input, { required: ['path', 'slug'] }, opts);
+  if (value === undefined) return undefined;
+  const path = validateString(value.path, incrementOptions('path', opts));
+  const slug = validateString(value.slug, {
+    ...incrementOptions('slug', opts),
+    regex: '^[a-zA-Z0-9._-]+$',
+  });
+  if (!path || !slug) return undefined;
+  return { path, slug } as SiteProject;
+}
+
+export function validateSiteNavItem(input: any, opts: Options): SiteNavItem | undefined {
+  let value = validateObject(input, opts);
+  if (value === undefined) return undefined;
+  if (defined(value.children)) {
+    // validate as SiteNavFolder
+    value = validateKeys(value, { required: ['title', 'children'] }, opts);
+    if (value === undefined) return undefined;
+    const title = validateString(value.title, incrementOptions('title', opts));
+    const children = validateList(
+      value.children,
+      incrementOptions('children', opts),
+      (child, index) => {
+        return validateSiteNavItem(child, incrementOptions(`children.${index}`, opts));
+      },
+    );
+    if (title === undefined || !children) return undefined;
+    return { title, children } as SiteNavFolder;
+  }
+  // validate as SiteNavItem
+  value = validateKeys(value, { required: ['title', 'url'] }, opts);
+  if (value === undefined) return undefined;
+  const title = validateString(value.title, incrementOptions('title', opts));
+  const url = validateString(value.url, {
+    ...incrementOptions('url', opts),
+    regex: '^(/[a-zA-Z0-9._-]+){1,2}$',
+  });
+  if (title === undefined || !url) return undefined;
+  return { title, url } as SiteNavPage;
+}
+
+export function validateSiteAction(input: any, opts: Options) {
+  const value = validateObjectKeys(
+    input,
+    { required: ['title', 'url'], optional: ['static'] },
+    opts,
+  );
+  if (value === undefined) return undefined;
+  const title = validateString(value.title, incrementOptions('title', opts));
+  const url = validateUrl(value.url, incrementOptions('url', opts));
+  if (defined(value.static)) {
+    value.static = validateBoolean(value.static, incrementOptions('static', opts));
+  }
+  if (title === undefined || !url) return undefined;
+  return value as SiteAction;
+}
+
+function validateSiteDesign(input: any, opts: Options) {
+  const value = validateObjectKeys(input, { optional: ['hide_authors'] }, opts);
+  if (value === undefined) return undefined;
+  if (defined(value.hide_authors)) {
+    value.hide_authors = validateBoolean(
+      value.hide_authors,
+      incrementOptions('hide_authors', opts),
+    );
+  }
+  return value as SiteDesign;
+}
+
+function validateSiteAnalytics(input: any, opts: Options) {
+  const value = validateObjectKeys(input, { optional: ['google', 'plausible'] }, opts);
+  if (value === undefined) return undefined;
+  if (defined(value.google)) {
+    value.google = validateString(value.google, incrementOptions('google', opts));
+  }
+  if (defined(value.plausible)) {
+    value.plausible = validateString(value.plausible, incrementOptions('plausible', opts));
+  }
+  return value as SiteAnalytics;
+}
+
+export function validateSiteConfig(input: any, opts: Options) {
+  const value = validateObjectKeys(input, SITE_CONFIG_KEYS, opts);
+  if (value === undefined) return undefined;
+  const projects = validateList(
+    value.projects,
+    incrementOptions('projects', opts),
+    (proj, index) => {
+      return validateSiteProject(proj, incrementOptions(`projects.${index}`, opts));
+    },
+  );
+  const nav = validateList(value.nav, incrementOptions('nav', opts), (item, index) => {
+    return validateSiteNavItem(item, incrementOptions(`nav.${index}`, opts));
+  });
+  const actions = validateList(
+    value.actions,
+    incrementOptions('actions', opts),
+    (action, index) => {
+      return validateSiteAction(action, incrementOptions(`actions.${index}`, opts));
+    },
+  );
+  const domainsOpts = incrementOptions('domains', opts);
+  const domains = validateList(value.domains, domainsOpts, (domain) => {
+    return validateString(domain, { ...domainsOpts, regex: '^[a-zA-Z0-9._-]+.curve.space$' });
+  });
+  const output: Record<string, any> = {};
+  if (defined(value.twitter)) {
+    output.twitter = validateString(value.twitter, {
+      ...incrementOptions('twitter', opts),
+      regex: '^@?(w){1,15}$',
+    });
+  }
+  if (defined(value.logo)) {
+    output.logo = validateString(value.logo, incrementOptions('logo', opts));
+  }
+  if (defined(value.logoText)) {
+    output.logoText = validateString(value.logoText, incrementOptions('logoText', opts));
+  }
+  if (defined(value.favicon)) {
+    output.favicon = validateString(value.favicon, incrementOptions('favicon', opts));
+  }
+  if (defined(value.buildPath)) {
+    output.buildPath = validateString(value.buildPath, incrementOptions('buildPath', opts));
+  }
+  if (defined(value.analytics)) {
+    output.analytics = validateSiteAnalytics(value.analytics, incrementOptions('analytics', opts));
+  }
+  if (defined(value.design)) {
+    output.design = validateSiteDesign(value.design, incrementOptions('design', opts));
+  }
+  if (!projects || !nav || !actions || !domains) return undefined;
+  return { projects, nav, actions, domains, ...output } as SiteConfig;
+}

--- a/src/config/validators.ts
+++ b/src/config/validators.ts
@@ -1,0 +1,46 @@
+import { PROJECT_FRONTMATTER_KEYS, validateProjectFrontmatter } from '../frontmatter/validators';
+import {
+  defined,
+  incrementOptions,
+  Options,
+  validateObject,
+  validateKeys,
+  validateString,
+  validateUrl,
+  validateList,
+} from '../utils/validators';
+import { ProjectConfig } from './types';
+
+const PROJECT_CONFIG_KEYS = ['remote', 'index', 'exclude'].concat(PROJECT_FRONTMATTER_KEYS);
+
+/**
+ * Validate ProjectConfig object against the schema
+ */
+export function validateProjectConfig(input: any, opts: Options) {
+  const projectFrontmatter = validateProjectFrontmatter(input, { ...opts, warn: false });
+  let value = validateObject(input, opts);
+  value = validateKeys(value, { optional: PROJECT_CONFIG_KEYS }, opts);
+  if (defined(value.remote)) {
+    value.remote = validateUrl(value.remote, {
+      includes: 'curvenote.com',
+      ...incrementOptions('remote', opts),
+    });
+  }
+  if (defined(value.index)) {
+    // TODO: Warn if these files don't exist
+    value.index = validateString(value.index, incrementOptions('index', opts));
+  }
+  if (defined(value.exclude)) {
+    const excludeOpts = incrementOptions('exclude', opts);
+    value.exclude = validateList(value.exclude, excludeOpts).map((file) => {
+      return validateString(file, excludeOpts);
+    });
+  }
+  return { ...projectFrontmatter, ...value } as ProjectConfig;
+}
+
+function validateSiteProject(input: any, opts: Options) {}
+function validateSiteNavItem(input: any, opts: Options) {}
+function validateSiteAction(input: any, opts: Options) {}
+function validateSiteConfig(input: any, opts: Options) {}
+function validateConfig(input: any, opts: Options) {}

--- a/src/config/validators.ts
+++ b/src/config/validators.ts
@@ -63,7 +63,7 @@ function validateProjectConfigKeys(value: Record<string, any>, opts: Options) {
 export function validateProjectConfig(input: any, opts: Options) {
   const value = validateObjectKeys(input, PROJECT_CONFIG_KEYS, opts) || {};
   const projectConfig = validateProjectConfigKeys(value, opts);
-  return projectConfig as ProjectConfig;
+  return projectConfig;
 }
 
 export function validateSiteProject(input: any, opts: Options) {
@@ -124,7 +124,7 @@ export function validateSiteAction(input: any, opts: Options) {
   return value as SiteAction;
 }
 
-function validateSiteDesign(input: any, opts: Options) {
+export function validateSiteDesign(input: any, opts: Options) {
   const value = validateObjectKeys(input, { optional: ['hide_authors'] }, opts);
   if (value === undefined) return undefined;
   if (defined(value.hide_authors)) {
@@ -136,7 +136,7 @@ function validateSiteDesign(input: any, opts: Options) {
   return value as SiteDesign;
 }
 
-function validateSiteAnalytics(input: any, opts: Options) {
+export function validateSiteAnalytics(input: any, opts: Options) {
   const value = validateObjectKeys(input, { optional: ['google', 'plausible'] }, opts);
   if (value === undefined) return undefined;
   if (defined(value.google)) {
@@ -148,9 +148,8 @@ function validateSiteAnalytics(input: any, opts: Options) {
   return value as SiteAnalytics;
 }
 
-export function validateSiteConfig(input: any, opts: Options) {
-  const value = validateObjectKeys(input, SITE_CONFIG_KEYS, opts);
-  if (value === undefined) return undefined;
+export function validateSiteConfigKeys(value: Record<string, any>, opts: Options) {
+  const output: Record<string, any> = {};
   const projects = validateList(
     value.projects,
     incrementOptions('projects', opts),
@@ -170,13 +169,13 @@ export function validateSiteConfig(input: any, opts: Options) {
   );
   const domainsOpts = incrementOptions('domains', opts);
   const domains = validateList(value.domains, domainsOpts, (domain) => {
-    return validateString(domain, { ...domainsOpts, regex: '^[a-zA-Z0-9._-]+.curve.space$' });
+    // Very basic subdomain validation
+    return validateString(domain, { ...domainsOpts, regex: /^.+\..+\..+$/ });
   });
-  const output: Record<string, any> = {};
   if (defined(value.twitter)) {
     output.twitter = validateString(value.twitter, {
       ...incrementOptions('twitter', opts),
-      regex: '^@?(w){1,15}$',
+      regex: /^@?(\w){1,15}$/,
     });
   }
   if (defined(value.logo)) {
@@ -199,4 +198,11 @@ export function validateSiteConfig(input: any, opts: Options) {
   }
   if (!projects || !nav || !actions || !domains) return undefined;
   return { projects, nav, actions, domains, ...output } as SiteConfig;
+}
+
+export function validateSiteConfig(input: any, opts: Options) {
+  const value = validateObjectKeys(input, SITE_CONFIG_KEYS, opts);
+  if (value === undefined) return undefined;
+  const siteConfig = validateSiteConfigKeys(value, opts);
+  return siteConfig;
 }

--- a/src/frontmatter/frontmatter.spec.ts
+++ b/src/frontmatter/frontmatter.spec.ts
@@ -92,10 +92,11 @@ describe('validateVenue', () => {
     expect(validateVenue({}, opts)).toEqual({});
   });
   it('object with title/url returns self', async () => {
-    expect(validateVenue({ title: 'test', url: 'example.com' }, opts)).toEqual({
+    const venue = {
       title: 'test',
       url: 'http://example.com',
-    });
+    };
+    expect(validateVenue(venue, opts)).toEqual(venue);
   });
   it('string returns object with title', async () => {
     expect(validateVenue('test', opts)).toEqual({ title: 'test' });

--- a/src/frontmatter/validators.ts
+++ b/src/frontmatter/validators.ts
@@ -224,7 +224,7 @@ export function validateNumbering(input: any, opts: Options) {
   return value as Numbering;
 }
 
-function validateSiteFrontmatterKeys(value: Record<string, any>, opts: Options) {
+export function validateSiteFrontmatterKeys(value: Record<string, any>, opts: Options) {
   const output: SiteFrontmatter = {};
   if (defined(value.title)) {
     output.title = validateString(value.title, incrementOptions('title', opts));
@@ -238,13 +238,13 @@ function validateSiteFrontmatterKeys(value: Record<string, any>, opts: Options) 
   return output;
 }
 
-function validateProjectFrontmatterKeys(value: Record<string, any>, opts: Options) {
+export function validateProjectFrontmatterKeys(value: Record<string, any>, opts: Options) {
   const output: ProjectFrontmatter = {};
   if (defined(value.authors)) {
     output.authors = validateList(
       value.authors,
       incrementOptions('authors', opts),
-      (author, index: number) => {
+      (author, index) => {
         return validateAuthor(author, incrementOptions(`authors.${index}`, opts));
       },
     );

--- a/src/frontmatter/validators.ts
+++ b/src/frontmatter/validators.ts
@@ -334,7 +334,10 @@ function validatePageFrontmatterKeys(value: Record<string, any>, opts: Options) 
     output.subtitle = validateString(value.subtitle, incrementOptions('subtitle', opts));
   }
   if (defined(value.short_title)) {
-    output.short_title = validateString(value.short_title, incrementOptions('short_title', opts));
+    output.short_title = validateString(value.short_title, {
+      ...incrementOptions('short_title', opts),
+      maxLength: 40,
+    });
   }
   if (defined(value.date)) {
     output.date = validateDate(value.date, incrementOptions('date', opts));

--- a/src/licenses/licenses.spec.ts
+++ b/src/licenses/licenses.spec.ts
@@ -1,6 +1,6 @@
 import { basicLogger, LogLevel } from '../logging';
 import { Options } from '../utils/validators';
-import { validateLicense, validateLicenses } from './validators';
+import { licensesToString, validateLicense, validateLicenses } from './validators';
 
 const TEST_LICENSE = {
   title: 'Creative Commons Attribution 4.0 International',
@@ -53,5 +53,76 @@ describe('validateLicenses', () => {
   });
   it('valid content object coerces', async () => {
     expect(validateLicenses({ content: 'CC-BY-4.0' }, opts)).toEqual({ content: TEST_LICENSE });
+  });
+});
+
+describe('licensesToString', () => {
+  it('empty licenses returns self', async () => {
+    expect(licensesToString({})).toEqual({});
+  });
+  it('content licenses returns content string', async () => {
+    expect(
+      licensesToString({
+        content: {
+          title: 'Creative Commons Attribution Share Alike 4.0 International',
+          id: 'CC-BY-SA-4.0',
+          CC: true,
+          free: true,
+          url: 'https://example.com',
+        },
+      }),
+    ).toEqual({ content: 'CC-BY-SA-4.0' });
+  });
+  it('code licenses returns code string', async () => {
+    expect(
+      licensesToString({
+        code: {
+          title: 'Creative Commons Attribution Share Alike 4.0 International',
+          id: 'CC-BY-SA-4.0',
+          CC: true,
+          free: true,
+          url: 'https://example.com',
+        },
+      }),
+    ).toEqual({ code: 'CC-BY-SA-4.0' });
+  });
+  it('matching content/code licenses returns string', async () => {
+    expect(
+      licensesToString({
+        content: {
+          title: 'Creative Commons Attribution Share Alike 4.0 International',
+          id: 'CC-BY-SA-4.0',
+          CC: true,
+          free: true,
+          url: 'https://example.com',
+        },
+        code: {
+          title: 'Creative Commons Attribution Share Alike 4.0 International',
+          id: 'CC-BY-SA-4.0',
+          CC: true,
+          free: true,
+          url: 'https://example.com',
+        },
+      }),
+    ).toEqual('CC-BY-SA-4.0');
+  });
+  it('content/code licenses returns content/code strings', async () => {
+    expect(
+      licensesToString({
+        content: {
+          title: 'Creative Commons Attribution Share Alike 4.0 International',
+          id: 'CC-BY-SA-4.0',
+          CC: true,
+          free: true,
+          url: 'https://example.com',
+        },
+        code: {
+          title: 'Creative Commons Attribution No Derivatives 4.0 International',
+          id: 'CC-BY-ND-4.0',
+          CC: true,
+          url: 'https://example.com',
+        },
+      }),
+    ).toEqual({ content: 'CC-BY-SA-4.0', code: 'CC-BY-ND-4.0' });
   });
 });

--- a/src/licenses/validators.ts
+++ b/src/licenses/validators.ts
@@ -107,3 +107,18 @@ export function validateLicenses(input: any, opts: Options): Licenses | undefine
   }
   return value;
 }
+
+export function licensesToString(licenses: Licenses) {
+  let stringLicenses: string | { content?: string; code?: string } = {};
+  if (licenses.content && licenses.code && licenses.content.id === licenses.code.id) {
+    stringLicenses = licenses.content.id;
+  } else {
+    if (licenses.content) {
+      stringLicenses.content = licenses.content.id;
+    }
+    if (licenses.code) {
+      stringLicenses.code = licenses.code.id;
+    }
+  }
+  return stringLicenses;
+}

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
 import { createStore, Store } from 'redux';
 import { JsonObject } from '@curvenote/blocks';
-import { loadSiteConfigOrThrow, loadProjectConfigOrThrow } from '../config';
+import { loadConfigOrThrow } from '../config';
 import { CURVENOTE_YML } from '../config/types';
 import { basicLogger, Logger, LogLevel } from '../logging';
 import { rootReducer, RootState, selectors } from '../store';
@@ -28,31 +28,26 @@ function withQuery(url: string, query: Record<string, string> = {}) {
 
 export function loadAllConfigs(session: Pick<ISession, 'log' | 'store'>) {
   try {
-    loadSiteConfigOrThrow(session);
-    session.log.debug(`Loaded site config from "./${CURVENOTE_YML}"`);
+    loadConfigOrThrow(session, '.');
+    session.log.debug(`Loaded configs from "./${CURVENOTE_YML}"`);
   } catch (error) {
     // TODO: what error?
-    session.log.debug(`Failed to find or load site config from "./${CURVENOTE_YML}"`);
-  }
-  try {
-    loadProjectConfigOrThrow(session, '.');
-    session.log.debug(`Loaded project config from "./${CURVENOTE_YML}"`);
-  } catch (error) {
-    // TODO: what error?
-    session.log.debug(`Failed to find or load project config from "./${CURVENOTE_YML}"`);
+    session.log.debug(`Failed to find or load configs from "./${CURVENOTE_YML}"`);
   }
   const siteConfig = selectors.selectLocalSiteConfig(session.store.getState());
   if (!siteConfig) return;
-  siteConfig.projects.forEach((project) => {
-    try {
-      loadProjectConfigOrThrow(session, project.path);
-    } catch (error) {
-      // TODO: what error?
-      session.log.debug(
-        `Failed to find or load project config from "${project.path}/${CURVENOTE_YML}"`,
-      );
-    }
-  });
+  siteConfig.projects
+    .filter((project) => project.path !== '.') // already loaded
+    .forEach((project) => {
+      try {
+        loadConfigOrThrow(session, project.path);
+      } catch (error) {
+        // TODO: what error?
+        session.log.debug(
+          `Failed to find or load project config from "${project.path}/${CURVENOTE_YML}"`,
+        );
+      }
+    });
 }
 
 export class Session implements ISession {

--- a/src/store/local/actions.ts
+++ b/src/store/local/actions.ts
@@ -325,13 +325,16 @@ export async function processProject(
   log.info(toc(`📚 Built ${pages.length} pages for ${siteProject.slug} in %s.`));
 }
 
-export async function processSite(session: ISession, watchMode = false): Promise<boolean> {
-  loadAllConfigs(session);
+export async function processSite(
+  session: ISession,
+  opts?: { reloadConfigs?: boolean; watchMode?: boolean },
+): Promise<boolean> {
+  if (opts?.reloadConfigs) loadAllConfigs(session);
   const siteConfig = selectors.selectLocalSiteConfig(session.store.getState());
   session.log.debug(`Site Config:\n\n${yaml.dump(siteConfig)}`);
   if (!siteConfig?.projects.length) return false;
   await Promise.all(
-    siteConfig.projects.map((siteProject) => processProject(session, siteProject, watchMode)),
+    siteConfig.projects.map((siteProject) => processProject(session, siteProject, opts?.watchMode)),
   );
   await writeSiteManifest(session);
   // Copy all assets

--- a/src/store/local/reducers.ts
+++ b/src/store/local/reducers.ts
@@ -15,22 +15,18 @@ export const projects = createSlice({
 
 export const config = createSlice({
   name: 'config',
-  initialState: { rawProjects: {}, projects: {} } as {
-    rawSite?: Record<string, any>;
+  initialState: { rawConfigs: {}, projects: {} } as {
+    rawConfigs: Record<string, Record<string, any>>;
     site?: SiteConfig;
-    rawProjects: Record<string, Record<string, any>>;
     projects: Record<string, ProjectConfig>;
   },
   reducers: {
-    receiveRawSite(state, action: PayloadAction<Record<string, any>>) {
-      state.rawSite = action.payload;
+    receiveRawConfig(state, action: PayloadAction<Record<string, any> & { path: string }>) {
+      const { path, ...payload } = action.payload;
+      state.rawConfigs[path] = payload;
     },
     receiveSite(state, action: PayloadAction<SiteConfig>) {
       state.site = action.payload;
-    },
-    receiveRawProject(state, action: PayloadAction<Record<string, any> & { path: string }>) {
-      const { path, ...payload } = action.payload;
-      state.rawProjects[path] = payload;
     },
     receiveProject(state, action: PayloadAction<ProjectConfig & { path: string }>) {
       const { path, ...payload } = action.payload;

--- a/src/store/local/reducers.ts
+++ b/src/store/local/reducers.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { combineReducers } from 'redux';
-import { ProjectConfig, SiteConfig, SiteProject } from '../../config/types';
+import { ProjectConfig, SiteConfig } from '../../config/types';
 import { LocalProject } from '../../toc/types';
 
 export const projects = createSlice({
@@ -15,15 +15,22 @@ export const projects = createSlice({
 
 export const config = createSlice({
   name: 'config',
-  initialState: { projects: {} } as { site?: SiteConfig; projects: Record<string, ProjectConfig> },
+  initialState: { rawProjects: {}, projects: {} } as {
+    rawSite?: Record<string, any>;
+    site?: SiteConfig;
+    rawProjects: Record<string, Record<string, any>>;
+    projects: Record<string, ProjectConfig>;
+  },
   reducers: {
+    receiveRawSite(state, action: PayloadAction<Record<string, any>>) {
+      state.rawSite = action.payload;
+    },
     receiveSite(state, action: PayloadAction<SiteConfig>) {
       state.site = action.payload;
     },
-    receiveSiteProject(state, action: PayloadAction<SiteProject>) {
-      if (!state.site)
-        throw new Error('state.local.site is not defined, not executing "receiveSiteProject"');
-      state.site.projects.push(action.payload);
+    receiveRawProject(state, action: PayloadAction<Record<string, any> & { path: string }>) {
+      const { path, ...payload } = action.payload;
+      state.rawProjects[path] = payload;
     },
     receiveProject(state, action: PayloadAction<ProjectConfig & { path: string }>) {
       const { path, ...payload } = action.payload;

--- a/src/store/local/selectors.ts
+++ b/src/store/local/selectors.ts
@@ -3,12 +3,19 @@ import { LocalProject, LocalProjectPage } from '../../toc/types';
 
 import { RootState } from '../reducers';
 
-export function selectLocalProject(state: RootState, path: string): LocalProject | undefined {
-  return state.local.projects[path];
+export function selectLocalRawSiteConfig(state: RootState): Record<string, any> | undefined {
+  return state.local.config.rawSite;
 }
 
 export function selectLocalSiteConfig(state: RootState): SiteConfig | undefined {
   return state.local.config.site;
+}
+
+export function selectLocalRawProjectConfig(
+  state: RootState,
+  path: string,
+): Record<string, any> | undefined {
+  return state.local.config.rawProjects[path];
 }
 
 export function selectLocalProjectConfig(
@@ -16,6 +23,10 @@ export function selectLocalProjectConfig(
   path: string,
 ): ProjectConfig | undefined {
   return state.local.config.projects[path];
+}
+
+export function selectLocalProject(state: RootState, path: string): LocalProject | undefined {
+  return state.local.projects[path];
 }
 
 export function selectFileInfo(state: RootState, path: string) {

--- a/src/store/local/selectors.ts
+++ b/src/store/local/selectors.ts
@@ -3,19 +3,15 @@ import { LocalProject, LocalProjectPage } from '../../toc/types';
 
 import { RootState } from '../reducers';
 
-export function selectLocalRawSiteConfig(state: RootState): Record<string, any> | undefined {
-  return state.local.config.rawSite;
-}
-
 export function selectLocalSiteConfig(state: RootState): SiteConfig | undefined {
   return state.local.config.site;
 }
 
-export function selectLocalRawProjectConfig(
+export function selectLocalRawConfig(
   state: RootState,
   path: string,
 ): Record<string, any> | undefined {
-  return state.local.config.rawProjects[path];
+  return state.local.config.rawConfigs[path];
 }
 
 export function selectLocalProjectConfig(

--- a/src/sync/clone.ts
+++ b/src/sync/clone.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import fs from 'fs';
 import inquirer from 'inquirer';
 import { join } from 'path';
-import { loadConfigOrThrow, writeProjectConfig, writeSiteConfig } from '../config';
+import { loadConfigOrThrow, writeConfigs } from '../config';
 import { ProjectConfig, SiteConfig, SiteProject } from '../config/types';
 import { LogLevel } from '../logging';
 import { Project } from '../models';
@@ -83,14 +83,14 @@ export async function clone(
     remote,
     path,
   });
-  writeProjectConfig(session, siteProject.path, projectConfig);
+  writeConfigs(session, siteProject.path, { projectConfig });
   if (siteConfig) {
     const newSiteConfig: SiteConfig = {
       ...siteConfig,
       nav: [...siteConfig.nav, { title: projectConfig.title || '', url: `/${siteProject.slug}` }],
       projects: [...siteConfig.projects, siteProject],
     };
-    writeSiteConfig(session, '.', newSiteConfig);
+    writeConfigs(session, '.', { siteConfig: newSiteConfig });
   }
   await pullProject(session, siteProject.path, { level: LogLevel.info });
 }

--- a/src/sync/clone.ts
+++ b/src/sync/clone.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import fs from 'fs';
 import inquirer from 'inquirer';
 import { join } from 'path';
-import { loadProjectConfigOrThrow, writeProjectConfig, writeSiteConfig } from '../config';
+import { loadConfigOrThrow, writeProjectConfig, writeSiteConfig } from '../config';
 import { ProjectConfig, SiteConfig, SiteProject } from '../config/types';
 import { LogLevel } from '../logging';
 import { Project } from '../models';
@@ -44,13 +44,12 @@ export async function interactiveCloneQuestions(
     ]);
     path = projectPath;
   }
-  let projectConfig: ProjectConfig | undefined;
   try {
-    projectConfig = loadProjectConfigOrThrow(session, path);
+    loadConfigOrThrow(session, path);
   } catch {
     // Project config does not exist; good!
     // TODO: Add all sorts of other stuff for the project data that we know!!
-    projectConfig = getDefaultProjectConfig(project.data.title);
+    const projectConfig = getDefaultProjectConfig(project.data.title);
     projectConfig.remote = project.data.id;
     projectConfig.description = project.data.description;
     return {

--- a/src/sync/clone.ts
+++ b/src/sync/clone.ts
@@ -45,7 +45,9 @@ export async function interactiveCloneQuestions(
     path = projectPath;
   }
   try {
+    // Throw if project doesn't exist - that's what we want!
     loadConfigOrThrow(session, path);
+    if (!selectors.selectLocalProjectConfig(session.store.getState(), path)) throw Error();
   } catch {
     // Project config does not exist; good!
     // TODO: Add all sorts of other stuff for the project data that we know!!
@@ -58,7 +60,7 @@ export async function interactiveCloneQuestions(
     };
   }
   throw new Error(
-    `Project already exists: "${path}, did you mean to ${chalk.bold('curvenote pull')}`,
+    `Project already exists: "${path}" - did you mean to ${chalk.bold('curvenote pull')}`,
   );
 }
 

--- a/src/sync/init.ts
+++ b/src/sync/init.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import fs from 'fs';
 import inquirer from 'inquirer';
 import { basename, resolve } from 'path';
-import { writeSiteConfig, writeProjectConfig } from '../config';
+import { writeConfigs } from '../config';
 import { CURVENOTE_YML, ProjectConfig } from '../config/types';
 import { docLinks, LOGO } from '../docs';
 import { LogLevel } from '../logging';
@@ -119,8 +119,8 @@ export async function init(session: ISession, opts: Options) {
     if (twitter) siteConfig.twitter = twitter;
   }
   // Save the configs to the state and write them to disk
-  writeSiteConfig(session, '.', siteConfig);
-  writeProjectConfig(session, path, projectConfig);
+  writeConfigs(session, '.', { siteConfig });
+  writeConfigs(session, path, { projectConfig });
 
   const pullOpts = { level: LogLevel.debug };
   let pullProcess: Promise<void> | undefined;

--- a/src/sync/pull.ts
+++ b/src/sync/pull.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import pLimit from 'p-limit';
-import { loadProjectConfigOrThrow } from '../config';
+import { loadConfigOrThrow } from '../config';
 import { projectToJupyterBook } from '../export';
 import { LogLevel, getLevel } from '../logging';
 import { Project } from '../models';
@@ -83,7 +83,7 @@ export async function pull(session: ISession, path?: string, opts?: Options) {
     );
     await pullProjects(session, { level: LogLevel.info });
   } else {
-    loadProjectConfigOrThrow(session, path);
+    loadConfigOrThrow(session, path);
     await confirmOrExit(
       `Pulling will overwrite all content in ${
         path === '.' ? 'current directory' : path

--- a/src/toc/index.ts
+++ b/src/toc/index.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { extname, parse, join, sep } from 'path';
-import { CURVENOTE_YML, SiteProject, SiteAction, AnalyticsConfig } from '../config/types';
+import { CURVENOTE_YML, SiteProject, SiteAction, SiteAnalytics } from '../config/types';
 import { JupyterBookChapter, readTOC } from '../export/jupyter-book/toc';
 import { allowNestedFrontmatter } from '../frontmatter';
 import { validateSiteFrontmatter } from '../frontmatter/validators';
@@ -291,8 +291,8 @@ function getSiteManifestAction(session: ISession, action: SiteAction): SiteActio
 
 function getSiteManifestAnalytics(
   session: ISession,
-  analytics?: AnalyticsConfig,
-): AnalyticsConfig | undefined {
+  analytics?: SiteAnalytics,
+): SiteAnalytics | undefined {
   if (!analytics) return undefined;
   const { google, plausible, ...rest } = analytics;
   warnOnUnrecognizedKeys(session.log, rest, `${CURVENOTE_YML}#site.analytics:`);

--- a/src/toc/types.ts
+++ b/src/toc/types.ts
@@ -1,5 +1,5 @@
 import { ProjectFrontmatter } from '../frontmatter/types';
-import { AnalyticsConfig, SiteAction, SiteNavItem } from '../config/types';
+import { SiteAnalytics, SiteAction, SiteNavItem } from '../config/types';
 
 // Types for local Project
 //
@@ -58,5 +58,5 @@ export type SiteManifest = {
   nav: SiteNavItem[];
   actions: SiteAction[];
   projects: ManifestProject[];
-  analytics?: AnalyticsConfig;
+  analytics?: SiteAnalytics;
 };

--- a/src/utils/validators.spec.ts
+++ b/src/utils/validators.spec.ts
@@ -8,6 +8,7 @@ import {
   validateDate,
   validateEmail,
   validateKeys,
+  validateList,
   validateObject,
   validateString,
   validateUrl,
@@ -105,9 +106,6 @@ describe('validateUrl', () => {
   it('valid value returns self', async () => {
     expect(validateUrl('https://example.com', opts)).toEqual('https://example.com');
   });
-  it('valid value without scheme coerces', async () => {
-    expect(validateUrl('example.com', opts)).toEqual('http://example.com');
-  });
   it('invalid string errors', async () => {
     expect(validateUrl('not a url', opts)).toEqual(undefined);
     expect(opts.count?.errors).toEqual(1);
@@ -117,17 +115,10 @@ describe('validateUrl', () => {
       'https://example.com',
     );
   });
-  it('valid value without scheme includes', async () => {
-    expect(validateUrl('example.com', { ...opts, includes: 'le.c' })).toEqual('http://example.com');
-  });
   it('valid value without includes errors', async () => {
     expect(validateUrl('https://example.com', { ...opts, includes: 'example.org' })).toEqual(
       undefined,
     );
-    expect(opts.count?.errors).toEqual(1);
-  });
-  it('valid value without includes errors', async () => {
-    expect(validateUrl('example.com', { ...opts, includes: 'example.org' })).toEqual(undefined);
     expect(opts.count?.errors).toEqual(1);
   });
 });
@@ -193,6 +184,33 @@ describe('validateKeys', () => {
   it('missing required keys errors', async () => {
     expect(validateKeys({ a: 1 }, { required: ['a', 'b'] }, opts)).toEqual(undefined);
     expect(opts.count?.errors).toEqual(1);
+  });
+});
+
+describe('validateList', () => {
+  it('empty list', async () => {
+    expect(validateList([], opts, (val) => val)).toEqual([]);
+  });
+  it('simple list and index', async () => {
+    expect(validateList(['a', 'b', 'c'], opts, (val, ind) => `${val} ${ind}`)).toEqual([
+      'a 0',
+      'b 1',
+      'c 2',
+    ]);
+  });
+  it('list filters undefined values', async () => {
+    expect(validateList(['a', 'b', 'c'], opts, (val) => (val === 'c' ? undefined : val))).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+  it('invalid object errors', async () => {
+    expect(validateList({}, opts, (val) => val)).toEqual(undefined);
+    expect(opts.count.errors).toEqual(1);
+  });
+  it('invalid string errors', async () => {
+    expect(validateList('abc', opts, (val) => val)).toEqual(undefined);
+    expect(opts.count.errors).toEqual(1);
   });
 });
 

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -65,7 +65,7 @@ export function validateBoolean(input: any, opts: Options) {
  */
 export function validateString(
   input: any,
-  opts: { maxLength?: number; regex?: string } & Options,
+  opts: { maxLength?: number; regex?: string | RegExp } & Options,
 ): string | undefined {
   if (typeof input !== 'string') return validationError(`must be string`, opts);
   const value = input as string;

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -165,7 +165,7 @@ export function validateKeys(
     }
   });
   if (required.length) {
-    return validationError(
+    validationError(
       `missing required key${required.length > 1 ? 's' : ''}: ${required.join(', ')}`,
       opts,
     );

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -9,6 +9,8 @@ export type Options = {
   count: { errors?: number; warnings?: number };
 };
 
+type KeyOptions = Options & { returnInvalidPartial?: boolean };
+
 export function defined(val: any) {
   return val != null;
 }
@@ -150,7 +152,7 @@ export function validateObject(input: any, opts: Options) {
 export function validateKeys(
   input: Record<string, any>,
   keys: { required?: string[]; optional?: string[] },
-  opts: Options,
+  opts: KeyOptions,
 ) {
   const value: Record<string, any> = {};
   let required = keys.required || [];
@@ -169,6 +171,7 @@ export function validateKeys(
       `missing required key${required.length > 1 ? 's' : ''}: ${required.join(', ')}`,
       opts,
     );
+    if (!opts.returnInvalidPartial) return undefined;
   }
   if (ignored.length) {
     validationMessage(
@@ -187,7 +190,7 @@ export function validateKeys(
 export function validateObjectKeys(
   input: any,
   keys: { required?: string[]; optional?: string[] },
-  opts: Options,
+  opts: KeyOptions,
 ) {
   const value = validateObject(input, opts);
   if (value === undefined) return undefined;

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -85,18 +85,13 @@ export function validateString(
  * If 'include' is provided, value must include it in the origin.
  */
 export function validateUrl(input: any, opts: { includes?: string } & Options) {
-  let value = validateString(input, { ...opts, maxLength: 2048 });
+  const value = validateString(input, { ...opts, maxLength: 2048 });
   if (value === undefined) return value;
   let url: URL;
   try {
     url = new URL(value);
   } catch {
-    try {
-      value = `http://${value}`;
-      url = new URL(value);
-    } catch {
-      return validationError('must be valid URL', opts);
-    }
+    return validationError('must be valid URL', opts);
   }
   if (opts.includes && !url.origin.includes(opts.includes)) {
     return validationError(`must include "${opts.includes}"`, opts);

--- a/src/web/watch.ts
+++ b/src/web/watch.ts
@@ -14,7 +14,7 @@ function watchConfigAndPublic(session: ISession) {
     .on('all', async (eventType: string, filename: string) => {
       session.log.debug(`File modified: "${filename}" (${eventType})`);
       session.log.info('💥 Triggered full site rebuild');
-      await processSite(session);
+      await processSite(session, { reloadConfigs: true });
     });
 }
 
@@ -26,7 +26,7 @@ function fileProcessor(session: ISession, siteProject: SiteProject) {
     changeFile(session, file, eventType);
     if (!KNOWN_FAST_BUILDS.has(extname(file))) {
       session.log.info('💥 Triggered full site rebuild');
-      await processSite(session);
+      await processSite(session, { reloadConfigs: true });
       return;
     }
     const pageSlug = selectors.selectPageSlug(session.store.getState(), siteProject.path, file);


### PR DESCRIPTION
- [x] Validate site/project config on read
- [x] Store raw and validated config
- [x] Ensure users only see error/warning messages once
- [x] When saving config, do not overwrite extra fields in original config file
- [x] Validate nav/project lists to warn on duplicate values - moved to https://github.com/curvenote/curvenotejs/issues/142