### PR TITLE
🐛  KaTeX: Unknown column alignment: *

### DIFF
--- a/src/transforms/math.spec.ts
+++ b/src/transforms/math.spec.ts
@@ -1,0 +1,55 @@
+import { silentLogger } from '../logging';
+import { transformMath } from './math';
+
+const ARRAY_ALIGN = `\\begin{align*}
+  L=
+  \\left(
+    \\begin{array}{*{16}c}
+       . &  &   &   &  &   &   &   \\\\
+      1 & .  &  &   &   &  &   &   \\\\
+        & 1 & . &  &   &   &  &   \\\\
+        &   & 1 & . &   &   &   &  \\\\
+      1 &   &   &   & . &  &   &     \\\\
+        & 1 &   &   & 1 & . &  &      \\\\
+        &   & 1 &   &   & 1 & . &    \\\\
+        &   &   & 1 &   &   & 1 & .   \\\\
+    \\end{array}
+  \\right),
+\\end{align*}`;
+
+const EQNARRAY = `\\mathbb{E}(\\hat{U}_{ij}) &=& (1-4 \\alpha) \\mathbb{E}(F_{ij}) + \\alpha( \\mathbb{E}(F_{i-1j}) + \\mathbb{E}(F_{i+1j}) + \\mathbb{E}(F_{ij-1}) + \\mathbb{E}(F_{ij+1})) \\\\ &=& (1-4 \\alpha) \\hat F_{ij} + \\alpha( \\hat F_{i-1j} + \\hat F_{i+1j} + \\hat F_{ij-1} + \\hat F_{ij+1}),`;
+
+describe('Test math trasformations', () => {
+  test('Array alignment', async () => {
+    const mathNode = { type: 'math', value: ARRAY_ALIGN } as any;
+    const mdast = { children: [mathNode] } as any;
+    transformMath(silentLogger(), mdast, {}, '');
+    expect(mathNode.error).toBeUndefined();
+    expect(mathNode.html).toBeTruthy();
+  });
+  test('Array alignment -- error', async () => {
+    const mathNode = {
+      type: 'math',
+      // Replace the expression with something that isn't caught
+      value: ARRAY_ALIGN.replace('{array}{*{16}c}', '{array}{*c}'),
+    } as any;
+    const mdast = { children: [mathNode] } as any;
+    transformMath(silentLogger(), mdast, {}, '');
+    expect(mathNode.error).toBe(true);
+    expect(mathNode.message.includes('Unknown column alignment')).toBe(true);
+  });
+  test('\\begin{eqnarray}', async () => {
+    const mathNode = { type: 'math', value: EQNARRAY } as any;
+    const mdast = { children: [mathNode] } as any;
+    const log = silentLogger();
+    expect.assertions(5);
+    log.warn = jest.fn((w) => {
+      expect(w.includes('\\begin{align*}')).toBe(true);
+      expect(w.includes("Expected 'EOF'")).toBe(true);
+    });
+    transformMath(log, mdast, {}, '');
+    expect(log.warn).toBeCalledTimes(1);
+    expect(mathNode.error).toBeUndefined();
+    expect(mathNode.html).toBeTruthy();
+  });
+});

--- a/src/transforms/math.ts
+++ b/src/transforms/math.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import katex from 'katex';
 import { Math, InlineMath } from 'myst-spec';
 import { selectAll } from 'mystjs';
@@ -27,13 +28,25 @@ function replaceEqnarray(log: Logger, value: string, file: string) {
     .replace(/\\end{eqnarray}/g, '\\end{align*}');
 }
 
+type RenderResult = { html?: string; warnings?: string[]; error?: string };
+
+function removeWarnings(result: RenderResult, predicate: (warning: string) => boolean) {
+  if (!result.warnings) return result;
+  const nextWarnings = result.warnings.filter(predicate);
+  if (nextWarnings.length === 0) return { html: result.html };
+  return {
+    ...result,
+    warnings: nextWarnings,
+  };
+}
+
 function tryRender(
   log: Logger,
   value: string,
   macros: Record<string, any>,
   displayMode: boolean,
   file: string,
-): { html?: string; warnings?: string[]; error?: string } {
+): RenderResult {
   const warnings: string[] = [];
   try {
     const html = katex.renderToString(value, {
@@ -48,7 +61,7 @@ function tryRender(
   } catch (error) {
     const { message } = error as unknown as Error;
     if (message.includes("Expected 'EOF', got '&' at position")) {
-      log.warn(`Wrapping math with \\begin{align*} in ${file} due to "${message}"`);
+      log.warn(`Math: Wrapping with \\begin{align*} in ${file}\n"${chalk.dim(message)}}"`);
       const result = tryRender(
         log,
         `\\begin{align*}\n${value}\n\\end{align*}`,
@@ -57,6 +70,18 @@ function tryRender(
         file,
       );
       if (result.html) return result;
+    }
+    if (message.includes('Unknown column alignment: *')) {
+      log.warn(`Math: Alignment of "*" not supported, using "c" in ${file}\n${chalk.dim(message)}`);
+      const arrayCentering = /\\begin{array}{((?:\*\{[0-9]+\})c)}/g;
+      if (value.match(arrayCentering)) {
+        const next = value.replace(arrayCentering, '\\begin{array}{c}');
+        const result = tryRender(log, next, macros, displayMode, file);
+        if (result.html) {
+          // We expect, and remove some errors
+          return removeWarnings(result, (w) => !w.includes('Too few columns specified'));
+        }
+      }
     }
     return { error: message };
   }
@@ -79,10 +104,14 @@ export function renderEquation(
     (node as any).html = result.html;
   }
   if (result.warnings) {
-    log.warn(`Math Warning: [${label}]:\n${result.warnings.join('\n')}\n\n${node.value}\n`);
+    log.warn(
+      `Math Warning [${label}] in ${file}:\n${result.warnings.join('\n')}\n\n${node.value}\n`,
+    );
   }
   if (result.error) {
-    log.error(`Math Error: [${label}]: ${result.error}\n\n${node.value}\n`);
+    log.error(
+      `Math Error [${label}] in ${file}:\n${chalk.dim(`${result.error}\n\n${node.value}\n`)}`,
+    );
     (node as any).error = true;
     (node as any).message = result.error;
   }

--- a/src/transforms/math.ts
+++ b/src/transforms/math.ts
@@ -61,7 +61,7 @@ function tryRender(
   } catch (error) {
     const { message } = error as unknown as Error;
     if (message.includes("Expected 'EOF', got '&' at position")) {
-      log.warn(`Math: Wrapping with \\begin{align*} in ${file}\n"${chalk.dim(message)}}"`);
+      log.warn(`Math: Wrapping with \\begin{align*} in ${file}\n${chalk.dim(message)}`);
       const result = tryRender(
         log,
         `\\begin{align*}\n${value}\n\\end{align*}`,

--- a/src/transforms/math.ts
+++ b/src/transforms/math.ts
@@ -31,11 +31,12 @@ function replaceEqnarray(log: Logger, value: string, file: string) {
 type RenderResult = { html?: string; warnings?: string[]; error?: string };
 
 function removeWarnings(result: RenderResult, predicate: (warning: string) => boolean) {
-  if (!result.warnings) return result;
-  const nextWarnings = result.warnings.filter(predicate);
-  if (nextWarnings.length === 0) return { html: result.html };
+  const { warnings, ...rest } = result;
+  if (!warnings) return rest;
+  const nextWarnings = warnings.filter(predicate);
+  if (nextWarnings.length === 0) return rest;
   return {
-    ...result,
+    ...rest,
     warnings: nextWarnings,
   };
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/913249/173451696-77802a78-30dd-4c59-b0f5-29a5687d278a.png)

Recovers for the input of `\begin{array}{*{16}c}` in this example (not supported in katex):
![image](https://user-images.githubusercontent.com/913249/173451756-b57b799d-dcaa-4fc3-957c-4f21f4fcce36.png)


Also tests #87.