### PR TITLE
🎨 Remove enumeration on slugs & improve titles

### DIFF
--- a/src/toc/index.ts
+++ b/src/toc/index.ts
@@ -1,3 +1,4 @@
+import { title2name as createSlug } from '@curvenote/blocks';
 import fs from 'fs';
 import { extname, parse, join, sep } from 'path';
 import { CURVENOTE_YML, SiteProject, SiteAction, SiteAnalytics } from '../config/types';
@@ -38,9 +39,27 @@ export function isDirectory(file: string): boolean {
   return fs.lstatSync(file).isDirectory();
 }
 
+function createTitle(s: string): string {
+  return (
+    s
+      // https://stackoverflow.com/questions/18379254/regex-to-split-camel-case
+      .split(/([A-Z][a-z0-9]+)|_|-/)
+      .filter((e) => e)
+      .join(' ')
+      .trim()
+      // Now make it into title case (simple, but good enough)
+      .replace(/\w\S*/g, (w) => w.replace(/^\w/, (c) => c.toUpperCase()))
+  );
+}
+
+function removeLeadingEnumeration(s: string): string {
+  return s.replace(/^([0-9_.-]+)/, '');
+}
+
 function fileInfo(file: string, pageSlugs: PageSlugs): { slug: string; title: string } {
-  let slug = parse(file).name.toLowerCase();
-  const title = slug;
+  const { name } = parse(file);
+  let slug = createSlug(removeLeadingEnumeration(name));
+  const title = createTitle(removeLeadingEnumeration(name));
   if (pageSlugs[slug]) {
     pageSlugs[slug] += 1;
     slug = `${slug}-${pageSlugs[slug] - 1}`;

--- a/src/toc/toc.spec.ts
+++ b/src/toc/toc.spec.ts
@@ -85,7 +85,7 @@ describe('site section generation', () => {
       citations: [],
       pages: [
         {
-          title: 'folder',
+          title: 'Folder',
           level: 1,
         },
         {
@@ -102,7 +102,10 @@ describe('site section generation', () => {
     });
   });
   it('nested folders', async () => {
-    mock({ 'readme.md': '', 'folder1/folder2/folder3': { 'page.md': '', 'notebook.ipynb': '' } });
+    mock({
+      'readme.md': '',
+      'folder1/01_MySecond_folder-ok/folder3': { '01_notebook.ipynb': '', '02_page.md': '' },
+    });
     expect(projectFromPath(session, '.')).toEqual({
       file: 'readme.md',
       path: '.',
@@ -110,24 +113,24 @@ describe('site section generation', () => {
       citations: [],
       pages: [
         {
-          title: 'folder1',
+          title: 'Folder1',
           level: 1,
         },
         {
-          title: 'folder2',
+          title: 'My Second Folder Ok',
           level: 2,
         },
         {
-          title: 'folder3',
+          title: 'Folder3',
           level: 3,
         },
         {
-          file: 'folder1/folder2/folder3/notebook.ipynb',
+          file: 'folder1/01_MySecond_folder-ok/folder3/01_notebook.ipynb',
           slug: 'notebook',
           level: 4,
         },
         {
-          file: 'folder1/folder2/folder3/page.md',
+          file: 'folder1/01_MySecond_folder-ok/folder3/02_page.md',
           slug: 'page',
           level: 4,
         },
@@ -155,11 +158,11 @@ describe('site section generation', () => {
       citations: [],
       pages: [
         {
-          title: 'folder2',
+          title: 'Folder2',
           level: 1,
         },
         {
-          title: 'folder3',
+          title: 'Folder3',
           level: 2,
         },
         {
@@ -189,7 +192,7 @@ describe('site section generation', () => {
       citations: [],
       pages: [
         {
-          title: 'folder',
+          title: 'Folder',
           level: 1,
         },
         {


### PR DESCRIPTION
Improve the default title for the implicit TOC, allowing it to be picked up. This also prettifies the slug and ensure that it is a valid curvenote "name" (using `@curvenote/blocks`).

* Removes preceding enumeration
* Adds titles that split on camel case or -/_ seps
* fixes spaces in slug bug (see below)

## Examples 

Both examples below have enumerated folder structures and notebooks that are nicely picked up and changed into slugs.

From this repo:
https://github.com/GeoStat-Examples/gstools-transform22-tutorial

![image](https://user-images.githubusercontent.com/913249/173486236-b2a2b67e-cc3d-4681-a3ae-7a163fab8990.png)


From this repo:
https://github.com/aquaULB/solving_pde_mooc

![image](https://user-images.githubusercontent.com/913249/173486480-1dab6303-31c7-4788-8ae6-a18f034a2277.png)


## Spaces cause errors:

![image](https://user-images.githubusercontent.com/913249/173495286-2e3c9a78-a47a-4993-ba26-c0d56f71813e.png)
