### PR TITLE
♳  enable session reload

### DIFF
--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -87,6 +87,10 @@ export class Session implements ISession {
     return url;
   }
 
+  reload() {
+    loadAllConfigs({ log: this.$logger, store: this.store });
+  }
+
   async get<T>(url: string, query?: Record<string, string>): Response<T> {
     const withBase = url.startsWith(this.API_URL) ? url : `${this.API_URL}${url}`;
     const fullUrl = withQuery(withBase, query);

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -20,6 +20,8 @@ export interface ISession {
 
   isAnon: boolean;
 
+  reload(): void;
+
   get<T extends JsonObject = JsonObject>(url: string, query?: Record<string, string>): Response<T>;
 
   post<T extends JsonObject = JsonObject>(url: string, data: JsonObject): Response<T>;


### PR DESCRIPTION
This allows users of the client library to programmatically update the `curvenote.yml` files and then reload the store via the session's standard loading routines.