### PR TITLE
📒 Move page kind from frontmatter to mdast cache

### DIFF
--- a/src/frontmatter/frontmatter.spec.ts
+++ b/src/frontmatter/frontmatter.spec.ts
@@ -84,7 +84,6 @@ const TEST_PAGE_FRONTMATTER: PageFrontmatter = {
   subtitle: 'sub',
   short_title: 'short',
   date: '14 Dec 2021',
-  kind: KINDS.Article,
 };
 
 const TEST_PROJECT: Project = {
@@ -266,10 +265,6 @@ describe('validatePageFrontmatter', () => {
   });
   it('invalid date errors', async () => {
     expect(validatePageFrontmatter({ date: 'https://example.com' }, opts)).toEqual({});
-    expect(opts.count.errors).toEqual(1);
-  });
-  it('invalid kind errors', async () => {
-    expect(validatePageFrontmatter({ kind: 'not article' }, opts)).toEqual({});
     expect(opts.count.errors).toEqual(1);
   });
 });
@@ -484,7 +479,6 @@ describe('pageFrontmatterFromDTO', () => {
     name: 'name',
     date: date.toISOString(),
     oxa: 'oxa:proj/block',
-    kind: KINDS.Article,
   };
   const block: Block = {
     id: {

--- a/src/frontmatter/types.ts
+++ b/src/frontmatter/types.ts
@@ -1,4 +1,4 @@
-import { Author as BlocksAuthor, KINDS } from '@curvenote/blocks';
+import { Author as BlocksAuthor } from '@curvenote/blocks';
 import { Licenses } from '../licenses/types';
 
 export type Author = Partial<BlocksAuthor>;
@@ -54,7 +54,6 @@ export type ProjectFrontmatter = SiteFrontmatter & {
 };
 
 export type PageFrontmatter = ProjectFrontmatter & {
-  kind?: KINDS;
   subtitle?: string;
   short_title?: string;
 };

--- a/src/frontmatter/validators.ts
+++ b/src/frontmatter/validators.ts
@@ -1,4 +1,3 @@
-import { KINDS } from '@curvenote/blocks';
 import { validate } from 'doi-utils';
 import { validateLicenses } from '../licenses/validators';
 import {
@@ -63,9 +62,7 @@ export const PROJECT_FRONTMATTER_KEYS = [
   'numbering',
   'math',
 ].concat(SITE_FRONTMATTER_KEYS);
-export const PAGE_FRONTMATTER_KEYS = ['kind', 'subtitle', 'short_title'].concat(
-  PROJECT_FRONTMATTER_KEYS,
-);
+export const PAGE_FRONTMATTER_KEYS = ['subtitle', 'short_title'].concat(PROJECT_FRONTMATTER_KEYS);
 
 export const USE_PROJECT_FALLBACK = [
   'authors',
@@ -354,15 +351,6 @@ export function validatePageFrontmatterKeys(value: Record<string, any>, opts: Op
       ...incrementOptions('short_title', opts),
       maxLength: 40,
     });
-  }
-  if (defined(value.kind)) {
-    const kindOpts = incrementOptions('kind', opts);
-    const kind = validateString(value.kind, kindOpts) as KINDS;
-    if (kind && !Object.values(KINDS).includes(kind as KINDS)) {
-      validationError(`invalid page kind ${kind}`, kindOpts);
-    } else {
-      output.kind = kind;
-    }
   }
   return output;
 }

--- a/src/store/local/actions.ts
+++ b/src/store/local/actions.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import yaml from 'js-yaml';
 import { convertHtmlToMdast, GenericNode, selectAll } from 'mystjs';
 import { extname, join, dirname } from 'path';
+import { KINDS } from '@curvenote/blocks';
 import { SiteProject } from '../../config/types';
 import { getPageFrontmatter } from '../../frontmatter';
 import { parseMyst, Root } from '../../myst';
@@ -25,7 +26,12 @@ import {
   transformLinks,
   transformCode,
 } from '../../transforms';
-import { References, RendererData, SingleCitationRenderer } from '../../transforms/types';
+import {
+  PreRendererData,
+  References,
+  RendererData,
+  SingleCitationRenderer,
+} from '../../transforms/types';
 import { copyActionResource, copyLogo, getSiteManifest, loadProjectFromDisk } from '../../toc';
 import { LocalProjectPage } from '../../toc/types';
 import { writeFileToFolder, serverPath, tic } from '../../utils';
@@ -36,7 +42,7 @@ import { watch } from './reducers';
 type ISessionWithCache = ISession & {
   $citationRenderers: Record<string, CitationRenderer>; // keyed on path
   $doiRenderers: Record<string, SingleCitationRenderer>; // keyed on doi
-  $mdast: Record<string, { pre: Root; post?: RendererData }>; // keyed on path
+  $mdast: Record<string, { pre: PreRendererData; post?: RendererData }>; // keyed on path
 };
 
 function castSession(session: ISession): ISessionWithCache {
@@ -97,12 +103,12 @@ export async function loadFile(session: ISession, path: string) {
   switch (ext) {
     case '.md': {
       const mdast = parseMyst(content);
-      cache.$mdast[path] = { pre: mdast };
+      cache.$mdast[path] = { pre: { mdast, kind: KINDS.Article } };
       break;
     }
     case '.ipynb': {
       const mdast = await processNotebook(cache, path, content);
-      cache.$mdast[path] = { pre: mdast };
+      cache.$mdast[path] = { pre: { mdast, kind: KINDS.Notebook } };
       break;
     }
     case '.bib': {
@@ -178,7 +184,7 @@ export async function transformMdast(
   const toc = tic();
   const { store, log } = session;
   const cache = castSession(session);
-  const mdastPre = cache.$mdast[file]?.pre;
+  const { mdast: mdastPre, kind } = cache.$mdast[file]?.pre;
   if (!mdastPre) throw new Error(`Expected mdast to be parsed for ${file}`);
   log.debug(`Processing "${file}"`);
   // Use structuredClone in future (available in node 17)
@@ -223,7 +229,7 @@ export async function transformMdast(
       }),
     );
   }
-  const data: RendererData = { sha256, frontmatter, mdast, references };
+  const data: RendererData = { sha256, frontmatter, mdast, references, kind };
   cache.$mdast[file].post = data;
   if (!watchMode) log.info(toc(`📖 Built ${file} in %s.`));
 }

--- a/src/store/local/actions.ts
+++ b/src/store/local/actions.ts
@@ -229,7 +229,7 @@ export async function transformMdast(
       }),
     );
   }
-  const data: RendererData = { sha256, frontmatter, mdast, references, kind };
+  const data: RendererData = { kind, sha256, frontmatter, mdast, references };
   cache.$mdast[file].post = data;
   if (!watchMode) log.info(toc(`📖 Built ${file} in %s.`));
 }

--- a/src/transforms/types.ts
+++ b/src/transforms/types.ts
@@ -1,5 +1,6 @@
 import { CitationRenderer } from 'citation-js-utils';
 import { GenericNode, map } from 'mystjs';
+import { KINDS } from '@curvenote/blocks';
 import { PageFrontmatter } from '../frontmatter/types';
 import { Root } from '../myst';
 
@@ -17,11 +18,15 @@ export type References = {
   footnotes: Footnotes;
 };
 
-export interface RendererData {
+export type PreRendererData = {
+  mdast: Root;
+  kind: KINDS;
+};
+
+export type RendererData = PreRendererData & {
   sha256: string;
   frontmatter: PageFrontmatter;
-  mdast: Root;
   references: References;
-}
+};
 
 export type SingleCitationRenderer = { id: string; render: CitationRenderer[''] };


### PR DESCRIPTION
`Kind` should not be on frontmatter - doesn't make sense for users to change this. Instead, it is just added to the `app/content` json, alongside `mdast`.

Should address #141 again.