### PR TITLE
Enable jupyter outputs in web build articles

### DIFF
--- a/src/export/jupyter-book/exportAll.ts
+++ b/src/export/jupyter-book/exportAll.ts
@@ -1,25 +1,19 @@
 import { Blocks, KINDS, NavListItemKindEnum } from '@curvenote/blocks';
 import { Version } from '../../models';
 import { ISession } from '../../session/types';
-import { articleToMarkdown } from '../markdown';
-import { notebookToIpynb } from '../notebook';
+import { articleToMarkdown, MarkdownExportOptions } from '../markdown';
+import { notebookToIpynb, NotebookExportOptions } from '../notebook';
 import { getLatestVersion } from '../utils/getLatest';
 import { ArticleState } from '../utils/walkArticle';
 import { writeBibtex } from '../utils/writeBibtex';
 
-interface Options {
-  path?: string;
-  images?: string;
-  bibtex?: string;
-  createFrontmatter?: boolean;
-  titleOnlyInFrontmatter?: boolean;
-  ignoreProjectFrontmatter?: boolean;
-}
+export type ExportAllOptions = Omit<MarkdownExportOptions, 'filename' | 'writeBibtex'> &
+  Omit<NotebookExportOptions, 'filename'>;
 
 export async function exportAll(
   session: ISession,
   nav: Version<Blocks.Navigation>,
-  opts?: Options,
+  opts?: ExportAllOptions,
 ) {
   const { bibtex = 'references.bib' } = opts ?? {};
   const blocks = await Promise.all(

--- a/src/export/jupyter-book/index.ts
+++ b/src/export/jupyter-book/index.ts
@@ -3,18 +3,12 @@ import { Project } from '../../models';
 import { ISession } from '../../session/types';
 import { exportFromProjectLink } from '../utils/exportWrapper';
 import { getLatestVersion } from '../utils/getLatest';
-import { exportAll } from './exportAll';
+import { exportAll, ExportAllOptions } from './exportAll';
 import { writeConfig } from './jbConfig';
 import { writeTOC } from './toc';
 
-type Options = {
-  path?: string;
+type Options = Omit<ExportAllOptions, 'bibtex'> & {
   writeConfig?: boolean;
-  images?: string;
-  bibtex?: string;
-  createFrontmatter?: boolean;
-  titleOnlyInFrontmatter?: boolean;
-  ignoreProjectFrontmatter?: boolean;
 };
 
 export async function projectToJupyterBook(session: ISession, projectId: ProjectId, opts: Options) {

--- a/src/export/markdown/index.ts
+++ b/src/export/markdown/index.ts
@@ -35,36 +35,8 @@ export type MarkdownExportOptions = {
 /**
  * Pull content from a version of kind Output, cache in mdast snippets, and return {mdast} directive
  *
- * This slightly restructures the notebook output from:
- *
- * [
- *   {
- *     "execution_count": 7,
- *     "output_type": "execute_result",
- *     "data": {
- *       "text/html": "...",
- *       ...
- *     }
- *   },
- *   ...
- * ]
- *
- * to
- *
- * [
- *   {
- *     "execution_count": 7,
- *     "output_type": "execute_result",
- *     "data": {
- *       "text/html": {
- *         "content": "...",
- *         "content_type": "text/html"
- *       },
- *       ...
- *     }
- *   },
- *   ...
- * ]
+ * Note: the output data cached here is directly from the API; it still needs to be minified in
+ * the transformOutputs transform.
  *
  */
 async function createOutputSnippet(
@@ -75,21 +47,6 @@ async function createOutputSnippet(
   const response = await fetch(version.data.links.download);
   if (!response.ok) return '';
   const outputData = (await response.json()) as Record<string, any>[];
-  // TODO: It would be nice if we could consume the notebook output structure as-is.
-  outputData.forEach((outputEntry) => {
-    Object.keys(outputEntry.data).forEach((content_type) => {
-      let outputContent = outputEntry.data[content_type];
-      if (typeof outputContent === 'object') {
-        outputContent = JSON.stringify(outputContent);
-      }
-      if (typeof outputContent === 'string') {
-        outputEntry.data[content_type] = {
-          content_type,
-          content: outputContent,
-        };
-      }
-    });
-  });
   const snippetId = `${name}#${createId()}`;
   mdastSnippets[snippetId] = {
     type: 'output',

--- a/src/export/markdown/index.ts
+++ b/src/export/markdown/index.ts
@@ -78,7 +78,10 @@ async function createOutputSnippet(
   // TODO: It would be nice if we could consume the notebook output structure as-is.
   outputData.forEach((outputEntry) => {
     Object.keys(outputEntry.data).forEach((content_type) => {
-      const outputContent = outputEntry.data[content_type];
+      let outputContent = outputEntry.data[content_type];
+      if (typeof outputContent === 'object') {
+        outputContent = JSON.stringify(outputContent);
+      }
       if (typeof outputContent === 'string') {
         outputEntry.data[content_type] = {
           content_type,

--- a/src/export/markdown/index.ts
+++ b/src/export/markdown/index.ts
@@ -1,3 +1,4 @@
+import { GenericNode } from 'mystjs';
 import path from 'path';
 import YAML from 'yaml';
 import { VersionId, KINDS, oxaLink, Blocks } from '@curvenote/blocks';
@@ -19,7 +20,7 @@ import { walkArticle } from '../utils/walkArticle';
 import { writeBibtex } from '../utils/writeBibtex';
 import { writeImagesToFiles } from '../utils/writeImagesToFiles';
 
-type Options = {
+export type MarkdownExportOptions = {
   path?: string;
   filename: string;
   images?: string;
@@ -94,7 +95,11 @@ async function createOutputSnippet(
   return `\`\`\`{mdast} ${snippetId}\n\`\`\``;
 }
 
-export async function articleToMarkdown(session: ISession, versionId: VersionId, opts: Options) {
+export async function articleToMarkdown(
+  session: ISession,
+  versionId: VersionId,
+  opts: MarkdownExportOptions,
+) {
   const [block, version] = await Promise.all([
     new Block(session, versionId).get(),
     new Version<Blocks.Article>(session, versionId).get(),

--- a/src/export/notebook/index.ts
+++ b/src/export/notebook/index.ts
@@ -14,14 +14,14 @@ import { assertEndsInExtension } from '../utils/assertions';
 import { exportFromOxaLink } from '../utils/exportWrapper';
 import { getChildren } from '../utils/getChildren';
 
-type Options = {
+export type NotebookExportOptions = {
   path?: string;
   filename: string;
-  createFrontmatter?: boolean;
+  createNotebookFrontmatter?: boolean;
   ignoreProjectFrontmatter?: boolean;
 };
 
-async function createFrontmatterCell(session: ISession, block: Block, opts: Options) {
+async function createFrontmatterCell(session: ISession, block: Block, opts: NotebookExportOptions) {
   const project = await new Project(session, block.id.project).get();
   saveAffiliations(session, project.data);
   let frontmatter = pageFrontmatterFromDTO(session, block.data);
@@ -38,7 +38,11 @@ async function createFrontmatterCell(session: ISession, block: Block, opts: Opti
   };
 }
 
-export async function notebookToIpynb(session: ISession, versionId: VersionId, opts: Options) {
+export async function notebookToIpynb(
+  session: ISession,
+  versionId: VersionId,
+  opts: NotebookExportOptions,
+) {
   assertEndsInExtension(opts.filename, 'ipynb');
   const [block, version] = await Promise.all([
     new Block(session, versionId).get(),
@@ -51,7 +55,7 @@ export async function notebookToIpynb(session: ISession, versionId: VersionId, o
   // NOTE: this should be handled better in the client.
   const resp = await session.get(`${version.$createUrl()}/download`);
   if (!resp.ok) throw new Error(`Could not download notebook.`);
-  if (opts.createFrontmatter) {
+  if (opts.createNotebookFrontmatter) {
     // Put a frontmatter cell in the front!
     const frontmatterCell = await createFrontmatterCell(session, block, opts);
     resp.json.cells = [frontmatterCell, ...resp.json.cells];

--- a/src/export/utils/walkArticle.ts
+++ b/src/export/utils/walkArticle.ts
@@ -173,7 +173,7 @@ export async function walkArticle(
             if (state == null) return {};
             return { state, block: childBlock, version };
           }
-          return {};
+          return { block: childBlock, version };
         }
         default:
           return {};

--- a/src/store/local/actions.ts
+++ b/src/store/local/actions.ts
@@ -201,7 +201,7 @@ export async function transformMdast(
   cache.$citationRenderers[file] = await transformLinkedDOIs(log, mdast, cache.$doiRenderers, file);
   ensureBlockNesting(mdast);
   transformMath(log, mdast, frontmatter, file);
-  transformOutputs(mdast);
+  await transformOutputs(session, mdast, kind);
   // Combine file-specific citation renderers with project renderers from bib files
   const fileCitationRenderer = combineRenderers(cache, projectPath, file);
   transformCitations(log, mdast, fileCitationRenderer, references);

--- a/src/sync/pull.ts
+++ b/src/sync/pull.ts
@@ -35,8 +35,9 @@ export async function pullProject(session: ISession, path: string, opts?: { leve
   await projectToJupyterBook(session, project.id, {
     path,
     writeConfig: false,
-    createFrontmatter: true,
+    createNotebookFrontmatter: true,
     titleOnlyInFrontmatter: true,
+    keepOutputs: true,
     // Project frontmatter is kept sepatare in project config, above
     ignoreProjectFrontmatter: true,
   });

--- a/src/transforms/outputs.ts
+++ b/src/transforms/outputs.ts
@@ -1,9 +1,29 @@
 import { GenericNode, selectAll } from 'mystjs';
-import { walkPaths } from '@curvenote/nbtx';
+import { CellOutput, KINDS } from '@curvenote/blocks';
+import { minifyCellOutput, walkPaths } from '@curvenote/nbtx';
 import { Root } from '../myst';
+import { ISession } from '../session';
+import { publicPath } from '../utils';
+import { createWebFileObjectFactory } from '../web/files';
 
-export function transformOutputs(mdast: Root) {
+export async function transformOutputs(session: ISession, mdast: Root, kind: KINDS) {
   const outputs = selectAll('output', mdast) as GenericNode[];
+
+  if (outputs && kind === KINDS.Article) {
+    const fileFactory = createWebFileObjectFactory(session.log, publicPath(session), '_static', {
+      useHash: true,
+    });
+    await Promise.all(
+      outputs.map(async (output) => {
+        output.data = await minifyCellOutput(
+          fileFactory,
+          output.data as CellOutput[],
+          { basepath: '' }, // fileFactory takes care of this
+        );
+      }),
+    );
+  }
+
   outputs.forEach((node) => {
     walkPaths(node.data, (p: string, obj: any) => {
       obj.path = `/${p}`;


### PR DESCRIPTION
This enables plotly, html, etc outputs in web builds when they are added to Articles on curvenote.com. It does not yet handle local (i.e. not versioned in curvenote) jupyter outputs updating when linked in curvenote articles.

Todo:
- [x] Move large output blobs out of site mdast and into public/_static (this is how they are handled already in Notebooks)

![image](https://user-images.githubusercontent.com/9453731/173888527-e62ad0fe-b04f-4841-949b-4634c619b42b.png)
