### PR TITLE
Add Site Frontmatter fallbacks on web build

### DIFF
--- a/src/frontmatter/frontmatter.spec.ts
+++ b/src/frontmatter/frontmatter.spec.ts
@@ -271,7 +271,7 @@ describe('validatePageFrontmatter', () => {
 
 describe('fillPageFrontmatter', () => {
   it('empty frontmatters return empty', async () => {
-    expect(fillPageFrontmatter({}, {})).toEqual({});
+    expect(fillPageFrontmatter({}, {}, {})).toEqual({});
   });
   it('page frontmatter returns self', async () => {
     expect(fillPageFrontmatter(TEST_PAGE_FRONTMATTER, {})).toEqual(TEST_PAGE_FRONTMATTER);
@@ -297,6 +297,11 @@ describe('fillPageFrontmatter', () => {
       ),
     ).toEqual({
       numbering: { enumerator: '#', heading_1: true, heading_5: true, heading_6: true },
+    });
+  });
+  it('site venue added', async () => {
+    expect(fillPageFrontmatter({}, {}, { venue: { title: 'my venue' } })).toEqual({
+      venue: { title: 'my venue' },
     });
   });
 });

--- a/src/frontmatter/index.ts
+++ b/src/frontmatter/index.ts
@@ -81,10 +81,10 @@ export function getPageFrontmatter(
   });
 
   const state = session.store.getState();
-  const projectFrontmatter: Record<string, any> =
-    selectors.selectLocalProjectConfig(state, path) ?? {};
+  const siteFrontmatter = selectors.selectLocalSiteConfig(state) ?? {};
+  const projectFrontmatter = selectors.selectLocalProjectConfig(state, path) ?? {};
 
-  const frontmatter = fillPageFrontmatter(pageFrontmatter, projectFrontmatter);
+  const frontmatter = fillPageFrontmatter(pageFrontmatter, projectFrontmatter, siteFrontmatter);
 
   const site = selectors.selectLocalSiteConfig(state);
   if (site?.design?.hide_authors) {

--- a/src/frontmatter/validators.ts
+++ b/src/frontmatter/validators.ts
@@ -64,6 +64,7 @@ export const PROJECT_FRONTMATTER_KEYS = [
 ].concat(SITE_FRONTMATTER_KEYS);
 export const PAGE_FRONTMATTER_KEYS = ['subtitle', 'short_title'].concat(PROJECT_FRONTMATTER_KEYS);
 
+export const USE_SITE_FALLBACK = ['venue'];
 export const USE_PROJECT_FALLBACK = [
   'authors',
   'date',
@@ -388,9 +389,11 @@ export function validatePageFrontmatter(input: any, opts: Options) {
 export function fillPageFrontmatter(
   pageFrontmatter: PageFrontmatter,
   projectFrontmatter: ProjectFrontmatter,
+  siteFrontmatter?: SiteFrontmatter,
 ) {
-  // TODO: Anything with SiteFrontmatter? Maybe 'site.venue' overrides other venues?
-  //       Or 'site.title' is used if no other title is available on project/page?
+  if (siteFrontmatter) {
+    projectFrontmatter = fillMissingKeys(projectFrontmatter, siteFrontmatter, USE_SITE_FALLBACK);
+  }
   const frontmatter = fillMissingKeys(pageFrontmatter, projectFrontmatter, USE_PROJECT_FALLBACK);
 
   // If numbering is an object, combine page and project settings.

--- a/src/toc/index.ts
+++ b/src/toc/index.ts
@@ -301,12 +301,13 @@ function getLogoPaths(
     session.log.debug('No logo specified, Curvespace renderer will use default logo');
     return null;
   }
+  const origLogoName = logoName;
   if (!fs.existsSync(logoName)) {
     // Look in the local public path
     logoName = join('public', logoName);
   }
   if (!fs.existsSync(logoName))
-    throw new Error(`Could not find logo at "${logoName}". See 'config.site.logo'`);
+    throw new Error(`Could not find logo at "${origLogoName}". See 'config.site.logo'`);
   const logo = `logo${extname(logoName)}`;
   return { path: logoName, public: join(publicPath(session), logo), url: `/${logo}` };
 }


### PR DESCRIPTION
For now, the only field that is used from site frontmatter is `venue`. Also, this only affects web builds since exports do not have a "site" associated with them.

![image](https://user-images.githubusercontent.com/9453731/174233304-22f42ff2-3f86-4b96-a7be-c42e91a586c7.png)
