### PR TITLE
Small changes to local links

### DIFF
--- a/src/transforms/images.ts
+++ b/src/transforms/images.ts
@@ -50,7 +50,7 @@ export async function transformImages(session: ISession, mdast: Root, filePath: 
     images.map(async (image) => {
       const oxa = oxaLinkToId(image.url);
       const imageLocalFile = path.join(filePath, image.url);
-      let file: string;
+      let file: string | undefined;
       if (oxa) {
         // If oxa, get the download url
         const versionId = oxa?.block as VersionId;
@@ -74,6 +74,7 @@ export async function transformImages(session: ISession, mdast: Root, filePath: 
       } else if (fs.existsSync(imageLocalFile)) {
         // Non-oxa, non-url local image paths relative to the config.section.path
         file = hashAndCopyStaticFile(session, imageLocalFile);
+        if (!file) return;
       } else if (isBase64(image.url)) {
         // Inline base64 images
         const fileObject = new WebFileObject(session.log, staticPath(session), '', true);

--- a/src/transforms/links.ts
+++ b/src/transforms/links.ts
@@ -89,6 +89,7 @@ function mutateRelativeLink(link: GenericNode, sitePath: string, target?: string
  */
 function mutateStaticLink(session: ISession, link: GenericNode, linkFile: string) {
   const file = hashAndCopyStaticFile(session, linkFile);
+  if (!file) return;
   if (!link.sourceUrl) link.sourceUrl = link.url;
   link.url = `/_static/${file}`;
   link.static = true;

--- a/src/transforms/links.ts
+++ b/src/transforms/links.ts
@@ -104,14 +104,16 @@ export function transformLinks(session: ISession, mdast: Root, file: string) {
       mutateOxaLink(session, link, oxa);
       return;
     }
+    if (link.url === '' || link.url.startsWith('#')) {
+      link.internal = true;
+      return;
+    }
     const linkFileWithTarget = fileFromRelativePath(sourceUrl, file);
     if (linkFileWithTarget) {
       const [linkFile, ...target] = linkFileWithTarget.split('#');
       const { url } = selectors.selectFileInfo(session.store.getState(), linkFile) || {};
-      if (url) {
+      if (url != null) {
         mutateRelativeLink(link, url, target);
-      } else if (link.url === '' || link.url.startsWith('#')) {
-        link.internal = true;
       } else {
         mutateStaticLink(session, link, linkFile);
       }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -96,7 +96,7 @@ export function hashAndCopyStaticFile(session: ISession, file: string) {
   const fileHash = `${computeHash(file)}${path.extname(file)}`;
   const destination = path.join(staticPath(session), fileHash);
   if (fs.existsSync(destination)) {
-    session.log.debug(`Cached image found for: ${file}`);
+    session.log.debug(`Cached file found for: ${file}`);
   } else {
     try {
       fs.copyFileSync(file, destination);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -102,7 +102,8 @@ export function hashAndCopyStaticFile(session: ISession, file: string) {
       fs.copyFileSync(file, destination);
       session.log.debug(`File successfully copied: ${file}`);
     } catch {
-      session.log.error(`Error copying image: ${file}`);
+      session.log.error(`Error copying file: ${file}`);
+      return undefined;
     }
   }
   return fileHash;


### PR DESCRIPTION
Two minor things I noticed at the end of last week:
- [x] Move handling of same-page link refs earlier (e.g. `link.url = ''` or `link.url = '#target-only'`)
  - Previously, these URLs had to make it through the checks `if (linkFileWithTarget)` and `if (!url)` before they were correctly handled.
  - Now, we just handle them first, unambiguously, and return early.
- [x] Don't rewrite static links if content isn't actually copied
  - Previously, if we got the error `Error copying file: ...`, the link was still updated to the static, hashed value, despite that static file not existing
  - Now, if we are unable to copy the file, we do not rewrite the url.