### PR TITLE
📒 Use all jupyter outputs directly in web builds

### DIFF
--- a/src/export/markdown/index.ts
+++ b/src/export/markdown/index.ts
@@ -83,7 +83,10 @@ export async function articleToMarkdown(
       const blockData = { oxa: oxaLink('', child.version.id) };
       let md = '';
       let mdastSnippets: Record<string, GenericNode<Record<string, any>>> = {};
-      if (child.state) {
+      if (opts.keepOutputs && child.version.data.kind === KINDS.Output) {
+        // Reprocess output here, ignoring Output state from walkArticle
+        md = await createOutputSnippet(child.version, mdastName, mdastSnippets);
+      } else if (child.state) {
         const myst = toMyst(child.state.doc, {
           ...localization,
           renderers: { iframe: 'myst' },
@@ -93,9 +96,6 @@ export async function articleToMarkdown(
         });
         md = myst.content;
         mdastSnippets = myst.mdastSnippets;
-      }
-      if (opts.keepOutputs && !md && child.version.data.kind === KINDS.Output) {
-        md = await createOutputSnippet(child.version, mdastName, mdastSnippets);
       }
       if (Object.keys(mdastSnippets).length) {
         Object.assign(articleMdastSnippets, mdastSnippets);


### PR DESCRIPTION
Resolves https://github.com/curvenote/curvespace/issues/84

This overrides the handling of _all_ `Output` blocks for markdown export during web build, rather than just the `Output` blocks that `walkArticle` did not handle.

We are moving towards needing a refactor where `walkArticle` is customized for all export targets, but for now this is ok; we let `walkArticle` do whatever it wants with `Outputs`, then, in the case of web build, ignore that and do something else.

Anyway, plotly outputs still work and pandas tables look a little better: 

![image](https://user-images.githubusercontent.com/9453731/174468098-707a3a85-aeb7-490c-9ee2-a288b7330504.png)
