### PR TITLE
🔗 Add linkify: true to markdownit options

### DIFF
--- a/src/myst/index.ts
+++ b/src/myst/index.ts
@@ -8,6 +8,7 @@ export function parseMyst(content: string): Root {
   const myst = new MyST({
     roles: { ...reactiveRoles },
     directives: { ...directives },
+    markdownit: { linkify: true },
   });
   return myst.parse(content);
 }


### PR DESCRIPTION
Now that linkify is part of the markdownit config in mystjs - see https://github.com/executablebooks/mystjs/pull/53 - we can enable it here.