### PR TITLE
Enable init if project config is present

### DIFF
--- a/src/licenses/licenses.spec.ts
+++ b/src/licenses/licenses.spec.ts
@@ -24,8 +24,13 @@ describe('validateLicense', () => {
   it('valid string coerces', async () => {
     expect(validateLicense('CC-BY-4.0', opts)).toEqual(TEST_LICENSE);
   });
-  it('valid license output errors', async () => {
-    expect(validateLicense(TEST_LICENSE, opts)).toEqual(undefined);
+  it('valid license object passes', async () => {
+    expect(validateLicense(TEST_LICENSE, opts)).toEqual(TEST_LICENSE);
+  });
+  it('invalid license object fails', async () => {
+    expect(validateLicense({ ...TEST_LICENSE, url: 'https://example.com' }, opts)).toEqual(
+      undefined,
+    );
     expect(opts.count.errors).toEqual(1);
   });
 });

--- a/src/licenses/validators.ts
+++ b/src/licenses/validators.ts
@@ -64,6 +64,26 @@ function createURL(license: Omit<License, 'url'>): string {
  * Validate input to be known license id and return corresponding License object
  */
 export function validateLicense(input: any, opts: Options): License | undefined {
+  if (typeof input === 'object') {
+    const revalidated = validateLicense(input.id, {
+      ...opts,
+      suppressErrors: true,
+      suppressWarnings: true,
+    });
+    let equal = Boolean(revalidated);
+    if (revalidated) {
+      Object.entries(revalidated).forEach(([key, val]) => {
+        if (val !== input[key]) equal = false;
+      });
+    }
+    if (!equal) {
+      return validationError(
+        `invalid license object - use a valid license ID string instead, see https://spdx.org/licenses/`,
+        opts,
+      );
+    }
+    return revalidated;
+  }
   let value = validateString(input, opts);
   if (value === undefined) return undefined;
   value = value.toUpperCase();

--- a/src/sync/init.ts
+++ b/src/sync/init.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import inquirer from 'inquirer';
 import { basename, resolve } from 'path';
 import { writeConfigs } from '../config';
-import { CURVENOTE_YML, ProjectConfig } from '../config/types';
+import { CURVENOTE_YML } from '../config/types';
 import { docLinks, LOGO } from '../docs';
 import { LogLevel } from '../logging';
 import { MyUser } from '../models';

--- a/src/sync/init.ts
+++ b/src/sync/init.ts
@@ -76,18 +76,16 @@ export async function init(session: ISession, opts: Options) {
   if (opts.domain) session.log.info(`Using custom domain ${opts.domain}`);
   let path = '.';
   // Initialize config - error if it exists
-  if (
-    selectors.selectLocalSiteConfig(session.store.getState()) ||
-    selectors.selectLocalProjectConfig(session.store.getState(), '.')
-  ) {
+  if (selectors.selectLocalSiteConfig(session.store.getState())) {
     throw Error(
-      `The ${CURVENOTE_YML} config already exists, did you mean to ${chalk.bold(
+      `Site config in ${CURVENOTE_YML} config already exists, did you mean to ${chalk.bold(
         'curvenote add',
       )} or ${chalk.bold('curvenote start')}?`,
     );
   }
   const folderName = basename(resolve(path));
   const siteConfig = getDefaultSiteConfig(folderName);
+  let projectConfig = selectors.selectLocalProjectConfig(session.store.getState(), '.');
 
   // Load the user now, and wait for it below!
   let me: MyUser | Promise<MyUser> | undefined;
@@ -96,23 +94,24 @@ export async function init(session: ISession, opts: Options) {
   const folderIsEmpty = fs.readdirSync(path).length === 0;
   if (folderIsEmpty && opts.yes) throw Error('Cannot initialize an empty folder');
   let content;
-  if (!folderIsEmpty && opts.yes) content = 'folder';
+  if ((!folderIsEmpty && opts.yes) || projectConfig) content = 'folder';
   else {
     const response = await inquirer.prompt([questions.content({ folderIsEmpty })]);
     content = response.content;
   }
 
-  let projectConfig: ProjectConfig;
   let pullComplete = false;
   if (content === 'folder') {
-    let title = folderName;
-    if (!opts.yes) {
-      const promptTitle = await inquirer.prompt([
-        questions.title({ title: siteConfig.title || '' }),
-      ]);
-      title = promptTitle.title;
+    if (!projectConfig) {
+      let title = folderName;
+      if (!opts.yes) {
+        const promptTitle = await inquirer.prompt([
+          questions.title({ title: siteConfig.title || '' }),
+        ]);
+        title = promptTitle.title;
+      }
+      projectConfig = getDefaultProjectConfig(title);
     }
-    projectConfig = getDefaultProjectConfig(title);
     siteConfig.projects = [{ path, slug: basename(resolve(path)) }];
     pullComplete = true;
   } else if (content === 'curvenote') {

--- a/src/sync/init.ts
+++ b/src/sync/init.ts
@@ -102,7 +102,7 @@ export async function init(session: ISession, opts: Options) {
 
   let pullComplete = false;
   if (content === 'folder') {
-    if (!projectConfig) {
+    if (!projectConfig?.title) {
       let title = folderName;
       if (!opts.yes) {
         const promptTitle = await inquirer.prompt([
@@ -110,7 +110,11 @@ export async function init(session: ISession, opts: Options) {
         ]);
         title = promptTitle.title;
       }
-      projectConfig = getDefaultProjectConfig(title);
+      if (projectConfig) {
+        projectConfig = { ...projectConfig, title };
+      } else {
+        projectConfig = getDefaultProjectConfig(title);
+      }
     }
     siteConfig.projects = [{ path, slug: basename(resolve(path)) }];
     pullComplete = true;


### PR DESCRIPTION
If project config exists locally, you may still `curvenote init` and it will be used. Note - if project config is present, nothing will be pulled; it will only build from local content. If you need to pull remote content, either do that explicitly first or `curvenote init` without the project config.

Resolves #211 