### PR TITLE
Add option to auto-generate _toc.yml from cli

### DIFF
--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -29,7 +29,7 @@ export function makeCIOption() {
 }
 export function makeWriteTocOption() {
   return new Option(
-    '-t, --write-toc',
+    '--write-toc',
     'Generate editable _toc.yml file for project if it does not exist',
   ).default(false);
 }

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -27,3 +27,9 @@ export function makeForceOption() {
 export function makeCIOption() {
   return new Option('-ci, --ci', 'Perform a minimal build, for use on CI').default(false);
 }
+export function makeWriteTocOption() {
+  return new Option(
+    '-t, --write-toc',
+    'Generate editable _toc.yml file for project if it does not exist',
+  ).default(false);
+}

--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -1,7 +1,13 @@
 import { Command } from 'commander';
 import { sync } from '../index';
 import { clirun } from './utils';
-import { makeBranchOption, makeDomainOption, makeForceOption, makeYesOption } from './options';
+import {
+  makeBranchOption,
+  makeDomainOption,
+  makeForceOption,
+  makeYesOption,
+  makeWriteTocOption,
+} from './options';
 
 function makeInitCLI(program: Command) {
   const command = new Command('init')
@@ -10,6 +16,7 @@ function makeInitCLI(program: Command) {
     .addOption(makeBranchOption())
     .addOption(makeYesOption())
     .addOption(makeDomainOption())
+    .addOption(makeWriteTocOption())
     .action(clirun(sync.init, { program, hideNoTokenWarning: true }));
   return command;
 }

--- a/src/cli/web.ts
+++ b/src/cli/web.ts
@@ -7,6 +7,7 @@ import {
   makeCleanOption,
   makeForceOption,
   makeYesOption,
+  makeWriteTocOption,
 } from './options';
 
 function makeCurvespaceCleanCLI(program: Command) {
@@ -37,6 +38,7 @@ function makeCurvespaceStartCLI(program: Command) {
     .addOption(makeCleanOption())
     .addOption(makeForceOption())
     .addOption(makeBranchOption())
+    .addOption(makeWriteTocOption())
     .action(clirun(web.startServer, { program, requireSiteConfig: true }));
   return command;
 }

--- a/src/sync/init.ts
+++ b/src/sync/init.ts
@@ -21,6 +21,7 @@ type Options = {
   force?: boolean;
   yes?: boolean;
   domain?: string;
+  writeToc?: boolean;
 };
 
 const WELCOME = async (session: ISession) => `
@@ -160,7 +161,7 @@ export async function init(session: ISession, opts: Options) {
 
   let start = false;
   if (!opts.yes) {
-    const promptStart = await inquirer.prompt([questions.start()]);
+    const promptStart = await inquirer.prompt([questions.start(opts.writeToc)]);
     start = promptStart.start;
   }
   if (!start && !opts.yes) {

--- a/src/sync/questions.ts
+++ b/src/sync/questions.ts
@@ -49,10 +49,11 @@ function projectPath(path?: string) {
   };
 }
 
-function start() {
+function start(writeToc?: boolean) {
+  const tocMessage = writeToc ? 'write missing _toc.yml files and ' : '';
   return {
     name: 'start',
-    message: 'Would you like to start the curve.space local server now?',
+    message: `Would you like to ${tocMessage}start the curve.space local server now?`,
     type: 'confirm',
     default: true,
   };

--- a/src/toc/toc.spec.ts
+++ b/src/toc/toc.spec.ts
@@ -1,6 +1,6 @@
 import mock from 'mock-fs';
 import { Session } from '../session';
-import { projectFromPath } from '.';
+import { projectFromPath, tocFromProject } from '.';
 
 afterEach(() => mock.restore());
 
@@ -278,6 +278,196 @@ describe('site section generation', () => {
       index: 'notebook',
       citations: [],
       pages: [],
+    });
+  });
+});
+
+describe('tocFromProject', () => {
+  it('single root', async () => {
+    expect(
+      tocFromProject({
+        file: 'readme.md',
+        path: '.',
+        index: 'readme',
+        citations: [],
+        pages: [],
+      }),
+    ).toEqual({
+      format: 'jb-book',
+      root: 'readme',
+      chapters: [],
+    });
+  });
+  it('root and one page', async () => {
+    expect(
+      tocFromProject({
+        file: 'readme.md',
+        path: '.',
+        index: 'readme',
+        citations: [],
+        pages: [
+          {
+            file: 'a.md',
+            slug: 'a',
+            level: 1,
+          },
+        ],
+      }),
+    ).toEqual({
+      format: 'jb-book',
+      root: 'readme',
+      chapters: [
+        {
+          file: 'a',
+        },
+      ],
+    });
+  });
+  it('root and pages with different levels', async () => {
+    expect(
+      tocFromProject({
+        file: 'readme.md',
+        path: '.',
+        index: 'readme',
+        citations: [],
+        pages: [
+          {
+            file: 'a.md',
+            slug: 'a',
+            level: 1,
+          },
+          {
+            file: 'b.md',
+            slug: 'b',
+            level: 3,
+          },
+          {
+            file: 'c.md',
+            slug: 'c',
+            level: 1,
+          },
+        ],
+      }),
+    ).toEqual({
+      format: 'jb-book',
+      root: 'readme',
+      chapters: [
+        {
+          file: 'a',
+          sections: [
+            {
+              file: 'b',
+            },
+          ],
+        },
+        {
+          file: 'c',
+        },
+      ],
+    });
+  });
+  it('root and folder and page', async () => {
+    expect(
+      tocFromProject({
+        file: 'readme.md',
+        path: '.',
+        index: 'readme',
+        citations: [],
+        pages: [
+          {
+            title: 'folder',
+            level: 1,
+          },
+          {
+            file: 'b.md',
+            slug: 'b',
+            level: 3,
+          },
+        ],
+      }),
+    ).toEqual({
+      format: 'jb-book',
+      root: 'readme',
+      chapters: [
+        {
+          title: 'folder',
+          sections: [
+            {
+              file: 'b',
+            },
+          ],
+        },
+      ],
+    });
+  });
+  it('root and nested folders', async () => {
+    expect(
+      tocFromProject({
+        file: 'readme.md',
+        path: '.',
+        index: 'readme',
+        citations: [],
+        pages: [
+          {
+            title: 'folder',
+            level: 1,
+          },
+          {
+            title: 'folder',
+            level: 2,
+          },
+          {
+            title: 'folder',
+            level: 3,
+          },
+          {
+            file: 'a.md',
+            slug: 'a',
+            level: 4,
+          },
+          {
+            file: 'b.md',
+            slug: 'b',
+            level: 2,
+          },
+          {
+            file: 'c.md',
+            slug: 'c',
+            level: 3,
+          },
+        ],
+      }),
+    ).toEqual({
+      format: 'jb-book',
+      root: 'readme',
+      chapters: [
+        {
+          title: 'folder',
+          sections: [
+            {
+              title: 'folder',
+              sections: [
+                {
+                  title: 'folder',
+                  sections: [
+                    {
+                      file: 'a',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              file: 'b',
+              sections: [
+                {
+                  file: 'c',
+                },
+              ],
+            },
+          ],
+        },
+      ],
     });
   });
 });

--- a/src/web/prepare.ts
+++ b/src/web/prepare.ts
@@ -10,6 +10,7 @@ export type Options = {
   branch?: string;
   ci?: boolean;
   yes?: boolean;
+  writeToc?: boolean;
 };
 
 export function cleanBuiltFiles(session: ISession, info = true) {
@@ -27,7 +28,8 @@ export function ensureBuildFoldersExist(session: ISession) {
 }
 
 export async function buildSite(session: ISession, opts: Options): Promise<boolean> {
-  if (opts.force || opts.clean) cleanBuiltFiles(session);
+  const { writeToc, force, clean } = opts;
+  if (force || clean) cleanBuiltFiles(session);
   ensureBuildFoldersExist(session);
-  return processSite(session);
+  return processSite(session, { writeToc });
 }


### PR DESCRIPTION
Previously, if you pull from a curvenote project, we write _toc.yml to keep the structure consistent. However, `init`-ing a project from a local folder auto-generates the structure with no easy way to customize.

This pr adds an additional option `-t`/`--write-toc` to `curvenote init` and `curvenote start` which will write a _toc.yml file if it doesn't yet exist. This file will be used for all subsequent builds and may be edited by the user.

Potentially we could add a separate command to the cli for this that allows more customization options, similar to https://jupyterbook.org/en/stable/structure/toc.html#generate-a-table-of-contents-from-content-files

Also, this only handles customizing folder titles in the TOC, not pages; those are still generated from the files and must be customized there.

Resolves #150  