### PR TITLE
Improve init / toc generation with existing project config

### DIFF
--- a/src/sync/init.ts
+++ b/src/sync/init.ts
@@ -106,15 +106,19 @@ export async function init(session: ISession, opts: Options) {
   let pullComplete = false;
   let title = projectConfig?.title || siteConfig.title;
   if (content === 'folder') {
-    if (!opts.yes) {
-      const promptTitle = await inquirer.prompt([questions.title({ title: title || '' })]);
-      title = promptTitle.title;
-    }
     if (projectConfigPaths.length) {
       const pathListString = projectConfigPaths
         .map((p) => `  - ${join(p, CURVENOTE_YML)}`)
         .join('\n');
-      session.log.info(`👀 Found existing project config files on your path:\n${pathListString}`);
+      session.log.info(
+        `👀 ${chalk.bold(
+          'Found existing project config files on your path:',
+        )}\n${pathListString}\n`,
+      );
+    }
+    if (!opts.yes) {
+      const promptTitle = await inquirer.prompt([questions.title({ title: title || '' })]);
+      title = promptTitle.title;
     }
     if (!projectConfig) {
       try {

--- a/src/sync/questions.ts
+++ b/src/sync/questions.ts
@@ -68,15 +68,6 @@ function pull() {
   };
 }
 
-function createWorkingDirProject() {
-  return {
-    name: 'createWorkingDirProject',
-    message: 'Would you like to create an additional project for your current working directory?',
-    type: 'confirm',
-    default: false,
-  };
-}
-
 export default {
   title,
   content,
@@ -84,5 +75,4 @@ export default {
   projectPath,
   start,
   pull,
-  createWorkingDirProject,
 };

--- a/src/sync/questions.ts
+++ b/src/sync/questions.ts
@@ -68,6 +68,15 @@ function pull() {
   };
 }
 
+function createWorkingDirProject() {
+  return {
+    name: 'createWorkingDirProject',
+    message: 'Would you like to create an additional project for your current working directory?',
+    type: 'confirm',
+    default: false,
+  };
+}
+
 export default {
   title,
   content,
@@ -75,4 +84,5 @@ export default {
   projectPath,
   start,
   pull,
+  createWorkingDirProject,
 };

--- a/src/toc/index.ts
+++ b/src/toc/index.ts
@@ -362,7 +362,7 @@ export function loadProjectFromDisk(
     newProject = projectFromPath(session, path, index);
   }
   if (!newProject) {
-    throw new Error(`Could load project from ${path}`);
+    throw new Error(`Could not load project from ${path}`);
   }
   if (writeToc) {
     try {

--- a/src/toc/toc.spec.ts
+++ b/src/toc/toc.spec.ts
@@ -280,6 +280,71 @@ describe('site section generation', () => {
       pages: [],
     });
   });
+  it('stop traversing at curvenote.yml', async () => {
+    mock({
+      'readme.md': '',
+      folder: {
+        'page.md': '',
+        'notebook.ipynb': '',
+        newproj: { 'page.md': '', 'curvenote.yml': '' },
+      },
+    });
+    expect(projectFromPath(session, '.')).toEqual({
+      file: 'readme.md',
+      path: '.',
+      index: 'readme',
+      citations: [],
+      pages: [
+        {
+          title: 'Folder',
+          level: 1,
+        },
+        {
+          file: 'folder/notebook.ipynb',
+          slug: 'notebook',
+          level: 2,
+        },
+        {
+          file: 'folder/page.md',
+          slug: 'page',
+          level: 2,
+        },
+      ],
+    });
+  });
+  it('do not stop traversing at root curvenote.yml', async () => {
+    mock({
+      'curvenote.yml': '',
+      'readme.md': '',
+      folder: {
+        'page.md': '',
+        'notebook.ipynb': '',
+        newproj: { 'page.md': '', 'curvenote.yml': '' },
+      },
+    });
+    expect(projectFromPath(session, '.')).toEqual({
+      file: 'readme.md',
+      path: '.',
+      index: 'readme',
+      citations: [],
+      pages: [
+        {
+          title: 'Folder',
+          level: 1,
+        },
+        {
+          file: 'folder/notebook.ipynb',
+          slug: 'notebook',
+          level: 2,
+        },
+        {
+          file: 'folder/page.md',
+          slug: 'page',
+          level: 2,
+        },
+      ],
+    });
+  });
 });
 
 describe('tocFromProject', () => {

--- a/src/toc/toc.spec.ts
+++ b/src/toc/toc.spec.ts
@@ -1,6 +1,6 @@
 import mock from 'mock-fs';
 import { Session } from '../session';
-import { projectFromPath, tocFromProject } from '.';
+import { findProjectsOnPath, projectFromPath, tocFromProject } from '.';
 
 afterEach(() => mock.restore());
 
@@ -534,5 +534,46 @@ describe('tocFromProject', () => {
         },
       ],
     });
+  });
+});
+
+const SITE_CONFIG = `
+version: 1
+site:
+  projects: []
+  nav: []
+  actions: []
+  domains: []
+`;
+
+const PROJECT_CONFIG = `
+version: 1
+project: {}
+`;
+
+describe('findProjectPaths', () => {
+  it('site curvenote.ymls', async () => {
+    mock({
+      'curvenote.yml': SITE_CONFIG,
+      'readme.md': '',
+      folder: {
+        'page.md': '',
+        'notebook.ipynb': '',
+        newproj: { 'page.md': '', 'curvenote.yml': SITE_CONFIG },
+      },
+    });
+    expect(findProjectsOnPath(session, '.')).toEqual([]);
+  });
+  it('project curvenote.ymls', async () => {
+    mock({
+      'curvenote.yml': PROJECT_CONFIG,
+      'readme.md': '',
+      folder: {
+        'page.md': '',
+        'notebook.ipynb': '',
+        newproj: { 'page.md': '', 'curvenote.yml': PROJECT_CONFIG },
+      },
+    });
+    expect(findProjectsOnPath(session, '.')).toEqual(['.', 'folder/newproj']);
   });
 });


### PR DESCRIPTION
This PR addresses:
- [x] #220 - If a `curvenote.yml` exists in a subdirectory, the auto toc traversal will stop and not add that content to the project in the parent directory during `curvenote start`
- [x] #215 - If project configs exist on subfolders, these will be picked up during `curvenote init` and added to the `site.projects`. Users can then choose if they also want to create a root-level project config or not.
- [x] #221 - During `curvenote init` the `site.nav` is now populated with links to all projects found on `site.projects`