### PR TITLE
🚨 Rename getLatestVersion, improve error when nav is unsaved

### DIFF
--- a/src/export/jupyter-book/index.ts
+++ b/src/export/jupyter-book/index.ts
@@ -2,7 +2,7 @@ import { ProjectId, Blocks } from '@curvenote/blocks';
 import { Project } from '../../models';
 import { ISession } from '../../session/types';
 import { exportFromProjectLink } from '../utils/exportWrapper';
-import { getLatestVersion } from '../utils/getLatest';
+import { getBlockAndLatestVersion } from '../utils/getLatest';
 import { exportAll, ExportAllOptions } from './exportAll';
 import { writeConfig } from './jbConfig';
 import { writeTOC } from './toc';
@@ -11,11 +11,22 @@ type Options = Omit<ExportAllOptions, 'bibtex'> & {
   writeConfig?: boolean;
 };
 
+/**
+ * Write jupyterbook from project
+ *
+ * Logs an error if no version of the nav is saved.
+ */
 export async function projectToJupyterBook(session: ISession, projectId: ProjectId, opts: Options) {
   const [project, { version: nav }] = await Promise.all([
     new Project(session, projectId).get(),
-    getLatestVersion<Blocks.Navigation>(session, { project: projectId, block: 'nav' }),
+    getBlockAndLatestVersion<Blocks.Navigation>(session, { project: projectId, block: 'nav' }),
   ]);
+  if (!nav) {
+    session.log.error(
+      `Unable to load project "${project.data.name}" - do you need to save a draft?`,
+    );
+    return;
+  }
   if (opts.writeConfig ?? true) {
     writeConfig(session, {
       path: opts.path,

--- a/src/export/utils/exportWrapper.ts
+++ b/src/export/utils/exportWrapper.ts
@@ -1,7 +1,7 @@
 import { oxaLinkToId, ProjectId, VersionId } from '@curvenote/blocks';
 import { Block } from '../../models';
 import { ISession } from '../../session/types';
-import { getLatestVersion } from './getLatest';
+import { getBlockAndLatestVersion } from './getLatest';
 import { ArticleState } from './walkArticle';
 
 export const exportFromOxaLink =
@@ -25,8 +25,12 @@ export const exportFromOxaLink =
       );
     } else {
       // Here we will load up the latest version
-      const { version } = await getLatestVersion(session, id.block);
-      await exportArticle(session, version.id, { filename, ...opts });
+      const { version } = await getBlockAndLatestVersion(session, id.block);
+      if (!version) {
+        session.log.error('Could not download article; do you need to save the draft?');
+      } else {
+        await exportArticle(session, version.id, { filename, ...opts });
+      }
     }
   };
 

--- a/src/export/utils/getLatest.ts
+++ b/src/export/utils/getLatest.ts
@@ -2,18 +2,19 @@ import { ALL_BLOCKS, BlockId, versionIdToString } from '@curvenote/blocks';
 import { Block, Version, VersionQueryOpts } from '../../models';
 import { ISession } from '../../session/types';
 
-export async function getLatestVersion<T extends ALL_BLOCKS>(
+export async function getBlockAndLatestVersion<T extends ALL_BLOCKS>(
   session: ISession,
   blockId: BlockId,
   query?: VersionQueryOpts,
-) {
-  session.log.debug(`getLatestVersion(${JSON.stringify(blockId)})`);
+): Promise<{ block: Block; version?: Version<T> }> {
+  session.log.debug(`getBlockAndLatestVersion(${JSON.stringify(blockId)})`);
   const block = await new Block(session, blockId).get();
   const { latest_version } = block.data;
-  if (!latest_version)
-    throw new Error(
-      `Block with name "${block.data.name}" has no versions, do you need to save the draft?`,
-    );
+  if (!latest_version) {
+    const nameMessage = block.data.name ? `with name "${block.data.name}" ` : '';
+    session.log.debug(`Block ${nameMessage}has no versions, do you need to save the draft?`);
+    return { block };
+  }
   session.log.debug(`Requesting latest version ${latest_version}`);
   const versionId = { ...block.id, version: latest_version };
   session.log.debug(`Fetching latest version of block: ${versionIdToString(versionId)}`);

--- a/src/sync/pull.ts
+++ b/src/sync/pull.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import pLimit from 'p-limit';
+import { join } from 'path';
 import { projectFrontmatterFromDTO, saveAffiliations } from '../frontmatter/api';
 import { loadConfigOrThrow, writeConfigs } from '../config';
 import { projectToJupyterBook } from '../export';
@@ -41,7 +42,7 @@ export async function pullProject(session: ISession, path: string, opts?: { leve
     // Project frontmatter is kept sepatare in project config, above
     ignoreProjectFrontmatter: true,
   });
-  log(toc(`🚀 Pulled ${path} in %s`));
+  if (fs.existsSync(join(path, '_toc.yml'))) log(toc(`🚀 Pulled ${path} in %s`));
 }
 
 /**


### PR DESCRIPTION
This is attempting to address #108 and maybe #69 ... The biggest problem I could determine is the screenshot from #108 where an `UnhandledPromiseRejection` was appearing when trying to pull a project with a nav that has never been saved. In this case, there's just no content to pull, so we need to error, but I improved the error so it's just logged normally (no more stack trace).

Other unsaved blocks/articles should be handled fine too (I think they already were?) - But it's hard to reach that state through the app, since the nav isn't updated until the article is saved (so pull never tries to pull drafts...)